### PR TITLE
feat: ホーム画面のタブ切替をスワイプ（フリック）に対応

### DIFF
--- a/static/css/mobile-gestures.css
+++ b/static/css/mobile-gestures.css
@@ -1,0 +1,31 @@
+/* ========================================
+   Mobile Gestures - スワイプタブ切替の視覚フィードバック
+   ======================================== */
+
+/* スワイプ中のタブコンテンツ領域 */
+.diary-tab-content {
+  touch-action: pan-y;
+  overflow: hidden;
+  will-change: transform;
+}
+
+/* タブ切替時のハイライトエフェクト */
+.tab-btn.tab-highlight {
+  background: rgba(113, 196, 239, 0.25);
+  color: var(--accent-200);
+  transition: background 0.15s ease;
+}
+
+/* ダークモード */
+.dark-mode .tab-btn.tab-highlight,
+[data-theme="dark"] .tab-btn.tab-highlight {
+  background: rgba(113, 196, 239, 0.3);
+  color: var(--accent-100);
+}
+
+/* reduced-motion 対応 */
+@media (prefers-reduced-motion: reduce) {
+  .diary-tab-content {
+    will-change: auto;
+  }
+}

--- a/static/js/mobile-gestures.js
+++ b/static/js/mobile-gestures.js
@@ -1,380 +1,169 @@
 /**
- * mobile-gestures.js - スマートフォン向けジェスチャー対応とUI改善
- * カブログでのHTMXベースのスマートフォン操作性向上のための機能
- * タブ切り替え最適化版
+ * mobile-gestures.js - ホーム画面の日記カードタブをスワイプで切り替える
+ * .diary-tab-content 領域で左右スワイプを検出し、タブを切り替える
  */
 
-// デバッグモードを有効化
-const DEBUG = false;
+(function() {
+  'use strict';
 
-// デバッグログ関数
-function debugLog(...args) {
-  if (DEBUG) {
-    // console.log('[Swipe Debug]', ...args);
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  debugLog('DOM Content Loaded - Initializing mobile gestures');
-  
-  // スピードダイアルとの互換性確保
-  if (typeof window.speedDialInstance !== 'undefined') {
-    debugLog('Speed Dial already initialized, maintaining compatibility');
-  }
-
-  // モバイルデバイス判定 - デバッグ用にPC検証でも常に有効化
-  const isMobile = true; // デバッグ用に常にtrue - 本番環境では元の条件に戻す
-
-  // グローバルで共有するイベントハンドラーを定義
-  window.handleTouchStart = function(e) {
-    debugLog('Touch START on element', this.tagName, this.className, 'data-diary-id:', this.getAttribute('data-diary-id'));
-    
-    const touch = e.touches[0];
-    window.touchStartX = touch.clientX;
-    window.touchStartY = touch.clientY;
-    window.touchStartTime = Date.now();
-    
-    // 長押し検出用のタイマー設定
-    this.longPressTimer = setTimeout(() => {
-      debugLog('Long press detected');
-      const touchElement = this;
-      
-      // 長押しイベントをトリガー
-      if (this.hasAttribute('hx-trigger') && this.getAttribute('hx-trigger').includes('longpress')) {
-        const longPressEvent = new CustomEvent('longpress', {
-          bubbles: true,
-          cancelable: true
-        });
-        this.dispatchEvent(longPressEvent);
-        
-        // 振動フィードバック
-        if (navigator.vibrate) {
-          navigator.vibrate(50);
-        }
-        
-        touchElement.classList.add('long-press-active');
-        setTimeout(() => {
-          touchElement.classList.remove('long-press-active');
-        }, 300);
-      }
-    }, 500);
-  };
-
-  window.handleTouchMove = function(e) {
-    // 長押し検出をキャンセル
-    if (this.longPressTimer) {
-      clearTimeout(this.longPressTimer);
-      this.longPressTimer = null;
-    }
-    
-    const touch = e.touches[0];
-    window.touchEndX = touch.clientX;
-    window.touchEndY = touch.clientY;
-    
-    // 移動距離を計算
-    const diffX = window.touchEndX - window.touchStartX;
-    const diffY = Math.abs(window.touchEndY - window.touchStartY);
-    
-    // 水平方向の移動が大きい場合、スワイプとして処理
-    // タブ切り替えでは視覚的フィードバックのみ提供し、実際の切り替えはタッチ終了時に行う
-    if (Math.abs(diffX) > 30 && diffY < 50) {
-      debugLog('Swipe detected during movement', diffX, 'px');
-      
-      // ページスクロールを防止（タブ内のスワイプの場合のみ）
-      if (this.classList.contains('diary-card') || this.closest('.diary-card')) {
-        e.preventDefault();
-      }
-      
-      // 視覚的なフィードバックとして軽い移動効果を適用
-      this.style.transition = 'none';
-      this.style.transform = `translateX(${diffX/3}px)`; // 抵抗感を出すために移動量を3分の1に
-    }
-  };
-
-  window.handleTouchEnd = function(e) {
-    debugLog('Touch END on element', this.tagName, this.className);
-    
-    // 長押し検出をキャンセル
-    if (this.longPressTimer) {
-      clearTimeout(this.longPressTimer);
-      this.longPressTimer = null;
-    }
-    
-    // タッチ終了時の位置を取得
-    let finalX = window.touchEndX;
-    let finalY = window.touchEndY;
-    
-    if (e.changedTouches && e.changedTouches.length > 0) {
-      finalX = e.changedTouches[0].clientX;
-      finalY = e.changedTouches[0].clientY;
-    }
-    
-    const diffX = finalX - window.touchStartX;
-    const diffY = Math.abs(finalY - window.touchStartY);
-    const touchDuration = Date.now() - window.touchStartTime;
-    
-    debugLog('Touch ended with diffX:', diffX, 'diffY:', diffY, 'duration:', touchDuration);
-    
-    // スワイプの処理
-    const swipeThreshold = 80;
-    
-    if (Math.abs(diffX) > swipeThreshold && diffY < 50) {
-      debugLog('SWIPE ACTION TRIGGERED!', diffX > 0 ? 'RIGHT' : 'LEFT');
-      
-      // 振動フィードバック
-      if (navigator.vibrate) {
-        navigator.vibrate(25);
-      }
-      
-      // スワイプ方向を判定
-      const swipeDirection = diffX > 0 ? 'right' : 'left';
-      
-      // スワイプに対応するアクションをトリガー
-      handleSwipeAction(this, swipeDirection);
-      
-      // イベントをさらに伝播させない
-      e.stopPropagation();
-    }
-    
-    // トランスフォームアニメーションをリセット
-    this.style.transition = 'transform 0.3s ease-out';
-    this.style.transform = 'translateX(0)';
-    
-    // 短いタップとして処理（200ms以下のタッチ）
-    if (touchDuration < 200 && Math.abs(diffX) < 10 && diffY < 10) {
-      debugLog('Short tap detected');
-      
-      // タップ効果
-      this.classList.add('tap-active');
-      setTimeout(() => {
-        this.classList.remove('tap-active');
-      }, 150);
-    }
-  };
+  // スワイプ設定
+  const SWIPE_THRESHOLD = 50;       // スワイプと判定する最小水平距離 (px)
+  const VERTICAL_LIMIT = 60;        // 縦移動がこれを超えたらスクロールと判定 (px)
+  const DRAG_RESISTANCE = 3;        // ドラッグ中の移動量を割る値（抵抗感）
+  const ANIMATION_DURATION = 250;   // タブ切替アニメーション時間 (ms)
 
   /**
-   * スワイプアクションを処理
-   * 日記カードの場合はタブ切り替え、カレンダーの場合は月切り替え
+   * 記事内のタブボタン一覧を取得
    */
-  function handleSwipeAction(element, direction) {
-    // 日記カードの場合
-    const diaryCard = element.classList.contains('diary-card') ? element : element.closest('.diary-card');
-    
-    if (diaryCard) {
-      debugLog('Processing swipe action for diary card', diaryCard.getAttribute('data-diary-id'), 'direction:', direction);
-      
-      // タブコンテナを取得
-      const tabsContainer = diaryCard.querySelector('.nav-tabs');
-      if (!tabsContainer) {
-        debugLog('No tabs container found in diary card');
-        return;
-      }
-      
-      // 現在アクティブなタブを取得
-      const activeTab = tabsContainer.querySelector('.nav-link.active');
-      if (!activeTab) {
-        debugLog('No active tab found');
-        return;
-      }
-      
-      // すべてのタブボタンを配列として取得
-      const allTabs = Array.from(tabsContainer.querySelectorAll('.nav-link'));
-      const currentIndex = allTabs.indexOf(activeTab);
-      
-      debugLog('Current active tab index:', currentIndex, 'total tabs:', allTabs.length);
-      
-      let nextIndex = currentIndex;
-      
-      // 次または前のタブのインデックスを計算
-      if (direction === 'left' && currentIndex < allTabs.length - 1) {
-        // 左スワイプ → 次のタブ
-        nextIndex = currentIndex + 1;
-      } else if (direction === 'right' && currentIndex > 0) {
-        // 右スワイプ → 前のタブ
-        nextIndex = currentIndex - 1;
-      }
-      
-      // インデックスが変わった場合のみタブ切り替え
-      if (nextIndex !== currentIndex) {
-        debugLog('Switching to tab index:', nextIndex);
-        
-        // 選択したタブをハイライト
-        allTabs[nextIndex].classList.add('tab-highlight');
-        
-        // タブ切り替えイベントを発火
-        allTabs[nextIndex].click();
-        
-        // タブハイライト効果を遅延解除
-        setTimeout(() => {
-          allTabs[nextIndex].classList.remove('tab-highlight');
-        }, 300);
-      }
-    } 
-    // カレンダーの場合
-    else if (element.closest('#mobile-calendar-container') || element.closest('#desktop-calendar-container')) {
-      debugLog('Calendar swipe detected:', direction);
-      
-      const calendarContainer = element.closest('#mobile-calendar-container') || element.closest('#desktop-calendar-container');
-      
-      if (direction === 'right') {
-        // 右スワイプ：前月
-        const prevButton = calendarContainer.querySelector('.calendar-nav-button:first-child');
-        if (prevButton) prevButton.click();
-      } else {
-        // 左スワイプ：翌月
-        const nextButton = calendarContainer.querySelector('.calendar-nav-button:nth-child(2)');
-        if (nextButton) nextButton.click();
-      }
+  function getTabButtons(article) {
+    return Array.from(article.querySelectorAll('.diary-tabs .tab-btn'));
+  }
+
+  /**
+   * 現在アクティブなタブのインデックスを返す
+   */
+  function getActiveIndex(tabs) {
+    return tabs.findIndex(function(btn) { return btn.classList.contains('active'); });
+  }
+
+  /**
+   * 指定インデックスのタブをクリックして切り替える
+   * diary-tabs.js の click ハンドラが処理するため .click() で委譲
+   */
+  function switchToTab(tabs, index) {
+    if (index >= 0 && index < tabs.length) {
+      tabs[index].click();
     }
   }
 
-  // === 日記カードのスワイプ設定 ===
-  function setupDiaryCardSwipeHandler() {
-    debugLog('Setting up swipe handlers for all diary cards');
-    
-    // すべての日記カードにスワイプハンドラーを追加
-    const diaryCards = document.querySelectorAll('.diary-card');
-    debugLog(`Found ${diaryCards.length} diary cards`);
-    
-    diaryCards.forEach((card, index) => {
-      // 既存のイベントリスナーを削除
-      card.removeEventListener('touchstart', window.handleTouchStart);
-      card.removeEventListener('touchmove', window.handleTouchMove);
-      card.removeEventListener('touchend', window.handleTouchEnd);
-      
-      // 新しいイベントリスナーを追加
-      card.addEventListener('touchstart', window.handleTouchStart, {passive: true});
-      card.addEventListener('touchmove', window.handleTouchMove, {passive: false});
-      card.addEventListener('touchend', window.handleTouchEnd, {passive: true});
-      
-      debugLog(`Set up swipe handler for card ${index+1}/${diaryCards.length}`, card.getAttribute('data-diary-id'));
-    });
-  }
+  /**
+   * 各 diary-article 内の .diary-tab-content にスワイプハンドラを設定
+   */
+  function setupSwipeHandlers() {
+    var articles = document.querySelectorAll('.diary-article');
 
-  // 初期化関数呼び出し
-  setupDiaryCardSwipeHandler();
+    articles.forEach(function(article) {
+      var tabContent = article.querySelector('.diary-tab-content');
+      if (!tabContent) return;
 
-  // HTMX イベントリスナー - コンテンツ更新時にスワイプハンドラーを再設定
-  document.body.addEventListener('htmx:afterSwap', function(evt) {
-    debugLog('HTMX afterSwap event on', evt.detail.target.id);
-    
-    if (evt.detail.target.id === 'diary-container') {
-      // DOM更新を待ってから実行
-      setTimeout(() => {
-        debugLog('Re-applying swipe handlers after HTMX swap');
-        setupDiaryCardSwipeHandler();
-      }, 100);
-    }
-  });
+      // 既にセットアップ済みならスキップ
+      if (tabContent._swipeSetup) return;
+      tabContent._swipeSetup = true;
 
-  // タブなどの表示切り替え後にも再初期化
-  document.addEventListener('shown.bs.tab', function() {
-    debugLog('Tab shown event - reinitializing swipe handlers');
-    setTimeout(setupDiaryCardSwipeHandler, 50);
-  });
+      var startX = 0;
+      var startY = 0;
+      var moveX = 0;
+      var isTracking = false;
+      var isScrolling = null; // null=未判定, true=縦スクロール, false=横スワイプ
 
-  // リサイズイベントでも再初期化（レイアウト変更に対応）
-  window.addEventListener('resize', function() {
-    debugLog('Window resize - reinitializing swipe handlers');
-    setTimeout(setupDiaryCardSwipeHandler, 100);
-  });
+      tabContent.addEventListener('touchstart', function(e) {
+        var touch = e.touches[0];
+        startX = touch.clientX;
+        startY = touch.clientY;
+        moveX = 0;
+        isTracking = true;
+        isScrolling = null;
+        tabContent.style.transition = 'none';
+      }, { passive: true });
 
-  // オフライン検出イベントを追加
-  window.addEventListener('online', function() {
-    debugLog('Device is now online');
-  });
-  
-  window.addEventListener('offline', function() {
-    debugLog('Device is now offline');
-  });
-});
-/**
- * モバイル最適化版カブログのタブスワイプ機能
- */
-document.addEventListener('DOMContentLoaded', function() {
-  // スワイプインジケーターの追加
-  const addSwipeIndicators = function() {
-    document.querySelectorAll('.card-tabs').forEach(tabContainer => {
-      // すでに存在する場合は作成しない
-      if (tabContainer.querySelector('.swipe-indicator')) return;
-      
-      // 左右のスワイプインジケーターを追加
-      const leftIndicator = document.createElement('span');
-      leftIndicator.className = 'swipe-indicator left';
-      
-      const rightIndicator = document.createElement('span');
-      rightIndicator.className = 'swipe-indicator right';
-      
-      tabContainer.appendChild(leftIndicator);
-      tabContainer.appendChild(rightIndicator);
-    });
-  };
-  
-  // カードクリックイベントの処理
-  const setupCardClickHandler = function() {
-    document.querySelectorAll('.diary-card').forEach(card => {
-      card.addEventListener('click', function(e) {
-        // タブやボタンがクリックされた場合は何もしない
-        if (e.target.closest('.nav-link') || 
-            e.target.closest('button') || 
-            e.target.closest('a') ||
-            e.target.closest('.tab-content')) {
-          return;
-        }
-        
-        // カードのクリックで詳細ページへ移動
-        const diaryId = this.getAttribute('data-diary-id');
-        if (diaryId) {
-          window.location.href = `/stockdiary/${diaryId}/`;
-        }
-      });
-    });
-  };
-  
-  // スワイプ操作の処理強化
-  const enhanceSwipeHandling = function() {
-    // すでに定義されているスワイプ処理に追加機能を提供
-    const originalHandleSwipeAction = window.handleSwipeAction || function() {};
-    
-    window.handleSwipeAction = function(element, direction) {
-      // 元の処理を実行
-      originalHandleSwipeAction(element, direction);
-      
-      // 視覚的フィードバックを追加
-      const tabsContainer = element.querySelector('.card-tabs') || 
-                          element.closest('.diary-card')?.querySelector('.card-tabs');
-      
-      if (tabsContainer) {
-        // アクティブタブと全タブを取得
-        const activeTab = tabsContainer.querySelector('.nav-link.active');
-        const allTabs = Array.from(tabsContainer.querySelectorAll('.nav-link'));
-        
-        if (activeTab && allTabs.length > 1) {
-          const currentIndex = allTabs.indexOf(activeTab);
-          
-          // スワイプ方向に基づいて次/前のタブをハイライト
-          if (direction === 'left' && currentIndex < allTabs.length - 1) {
-            allTabs[currentIndex + 1].classList.add('tab-highlight');
-            setTimeout(() => allTabs[currentIndex + 1].classList.remove('tab-highlight'), 300);
-          } else if (direction === 'right' && currentIndex > 0) {
-            allTabs[currentIndex - 1].classList.add('tab-highlight');
-            setTimeout(() => allTabs[currentIndex - 1].classList.remove('tab-highlight'), 300);
+      tabContent.addEventListener('touchmove', function(e) {
+        if (!isTracking) return;
+
+        var touch = e.touches[0];
+        var diffX = touch.clientX - startX;
+        var diffY = touch.clientY - startY;
+
+        // 初回移動で方向を判定
+        if (isScrolling === null) {
+          if (Math.abs(diffY) > 10 || Math.abs(diffX) > 10) {
+            isScrolling = Math.abs(diffY) > Math.abs(diffX);
           }
         }
-      }
-    };
-  };
-  
-  // 機能の初期化
-  addSwipeIndicators();
-  setupCardClickHandler();
-  enhanceSwipeHandling();
-  
-  // HTMX イベントリスナー - コンテンツ更新時に機能を再初期化
-  document.body.addEventListener('htmx:afterSwap', function(evt) {
-    setTimeout(() => {
-      addSwipeIndicators();
-      setupCardClickHandler();
-    }, 100);
+
+        // 縦スクロールと判定されたら何もしない
+        if (isScrolling) return;
+
+        // 横スワイプと判定 — 縦移動が大きすぎたらキャンセル
+        if (Math.abs(diffY) > VERTICAL_LIMIT) {
+          isTracking = false;
+          tabContent.style.transform = '';
+          tabContent.style.transition = '';
+          return;
+        }
+
+        // スクロールを抑制して水平のドラッグフィードバックを表示
+        e.preventDefault();
+        moveX = diffX;
+        tabContent.style.transform = 'translateX(' + (diffX / DRAG_RESISTANCE) + 'px)';
+      }, { passive: false });
+
+      tabContent.addEventListener('touchend', function() {
+        if (!isTracking) return;
+        isTracking = false;
+
+        // アニメーション付きで元の位置に戻す
+        tabContent.style.transition = 'transform ' + ANIMATION_DURATION + 'ms ease-out';
+        tabContent.style.transform = '';
+
+        // スワイプ閾値チェック
+        if (Math.abs(moveX) < SWIPE_THRESHOLD) return;
+
+        var tabs = getTabButtons(article);
+        if (tabs.length <= 1) return;
+
+        var current = getActiveIndex(tabs);
+        var next = current;
+
+        if (moveX < -SWIPE_THRESHOLD && current < tabs.length - 1) {
+          // 左スワイプ → 次のタブ
+          next = current + 1;
+        } else if (moveX > SWIPE_THRESHOLD && current > 0) {
+          // 右スワイプ → 前のタブ
+          next = current - 1;
+        }
+
+        if (next !== current) {
+          // 触覚フィードバック
+          if (navigator.vibrate) {
+            navigator.vibrate(15);
+          }
+
+          // タブ切替ハイライト
+          tabs[next].classList.add('tab-highlight');
+          switchToTab(tabs, next);
+
+          setTimeout(function() {
+            tabs[next].classList.remove('tab-highlight');
+          }, 300);
+        }
+      }, { passive: true });
+
+      tabContent.addEventListener('touchcancel', function() {
+        isTracking = false;
+        tabContent.style.transition = 'transform ' + ANIMATION_DURATION + 'ms ease-out';
+        tabContent.style.transform = '';
+      }, { passive: true });
+    });
+  }
+
+  // --- 初期化 ---
+
+  // DOMContentLoaded で初期セットアップ
+  document.addEventListener('DOMContentLoaded', function() {
+    setupSwipeHandlers();
   });
-});
+
+  // HTMX でコンテンツが読み込まれた後に再セットアップ
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.detail.target.id === 'diary-container') {
+      setTimeout(setupSwipeHandlers, 100);
+    }
+  });
+
+  // HTMX の afterSettle でも再セットアップ（無限スクロール対応）
+  document.body.addEventListener('htmx:afterSettle', function(evt) {
+    if (evt.detail.target.id === 'diary-container') {
+      setTimeout(setupSwipeHandlers, 50);
+    }
+  });
+})();

--- a/stockdiary/templates/stockdiary/home.html
+++ b/stockdiary/templates/stockdiary/home.html
@@ -795,6 +795,7 @@
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.10.1/main.min.js"></script>
+<script src="{% static 'js/mobile-gestures.js' %}?v={{ STATIC_VERSION }}"></script>
 
 <script>
 // アドバンス検索の開閉


### PR DESCRIPTION
- mobile-gestures.js を正しいセレクタ(.diary-article, .diary-tabs, .tab-btn)で書き直し
- .diary-tab-content 領域でのタッチスワイプを検出してタブを切り替え
- 縦スクロールとの競合を防ぐ方向判定ロジックを実装
- スワイプ中のドラッグフィードバック表示とハイライトアニメーションを追加
- HTMX による無限スクロール後の再初期化に対応
- mobile-gestures.js を home.html に読み込みを追加

https://claude.ai/code/session_01WvBW3eeEKgA35d5Ac17RE9