### PR TITLE
サイドバー自動リンク：同一銘柄コードからメモ内言及コードへ変更

### DIFF
--- a/stockdiary/views.py
+++ b/stockdiary/views.py
@@ -647,15 +647,20 @@ class StockDiaryDetailView(ObjectNotFoundRedirectMixin, LoginRequiredMixin, Deta
         context['related_diaries'] = all_related_diaries.exclude(id=self.object.id)
         context['timeline_diaries'] = all_related_diaries
 
-        # 手動リンク + 自動リンク（同一銘柄）を統合した関連日記リスト
-        # 銘柄コードがある場合のみ自動リンクを有効にする
+        # 手動リンク + 自動リンク（メモ・投資理由に記載された4桁銘柄コード言及）を統合した関連日記リスト
         manual_linked_ids = set(self.object.linked_diaries.values_list('id', flat=True))
         combined_related = []
         for d in self.object.linked_diaries.select_related():
             combined_related.append({'diary': d, 'is_auto': False})
-        has_symbol = bool(self.object.stock_symbol and self.object.stock_symbol.strip())
-        if has_symbol:
-            for d in all_related_diaries.exclude(id=self.object.id):
+        # メモ・投資理由から4桁銘柄コードを抽出し、一致する日記を自動リンク
+        search_text = ' '.join(filter(None, [self.object.memo, self.object.reason]))
+        mentioned_codes = set(re.findall(r'\b\d{4}\b', search_text))
+        if mentioned_codes:
+            auto_diaries = StockDiary.objects.filter(
+                user=self.request.user,
+                stock_symbol__in=mentioned_codes
+            ).exclude(id=self.object.id)
+            for d in auto_diaries:
                 if d.id not in manual_linked_ids:
                     combined_related.append({'diary': d, 'is_auto': True})
         context['combined_related_diaries'] = combined_related


### PR DESCRIPTION
- 旧: 日記と同じ stock_symbol を持つ日記を自動リンクとして表示（タイムラインと重複）
- 新: memo / reason テキスト内に含まれる4桁銘柄コード（\b\d{4}\b）を検出し、 そのコードを stock_symbol として持つ日記を自動リンクとしてサイドバーに表示する

https://claude.ai/code/session_01LMnRBYVVcJXjtjbYNrX4QV