### PR TITLE
fix: qcluster起動エラー解消 - cpu_affinity の不正な設定を削除

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -733,7 +733,6 @@ Q_CLUSTER = {
     'compress': True,
     'save_limit': 100,
     'queue_limit': 300,
-    'cpu_affinity': [0, 1],
     'label': 'Django Q',
     'redis': {
         'host': '127.0.0.1',


### PR DESCRIPTION
Q_CLUSTER の cpu_affinity にリスト [0, 1] が設定されていたが
Django-Q は整数を期待するため TypeError でクラッシュしていた。
不要な設定のため削除。

https://claude.ai/code/session_01T29iQghzgdi5d9gTV59EKo