### PR TITLE
fix: NULLエラー解消とクイック日記のシンプル化

### DIFF
--- a/stockdiary/models.py
+++ b/stockdiary/models.py
@@ -49,13 +49,23 @@ class StockDiary(models.Model):
     average_purchase_price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True, verbose_name='平均取得単価')
     total_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='総取得原価')
     realized_profit = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='実現損益')
-    
+
     # 取引統計
     total_bought_quantity = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='累計購入数')
     total_sold_quantity = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='累計売却数')
     total_buy_amount = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='累計購入額')
     total_sell_amount = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='累計売却額')
     transaction_count = models.IntegerField(default=0, verbose_name='取引回数')
+
+    # 現物取引のみの集計フィールド（is_margin=False）
+    cash_only_current_quantity = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物保有数')
+    cash_only_average_purchase_price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True, verbose_name='現物平均取得単価')
+    cash_only_total_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物総原価')
+    cash_only_realized_profit = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物実現損益')
+    cash_only_total_bought_quantity = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物累計購入数')
+    cash_only_total_sold_quantity = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物累計売却数')
+    cash_only_total_buy_amount = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物累計購入額')
+    cash_only_total_sell_amount = models.DecimalField(max_digits=15, decimal_places=2, default=0, verbose_name='現物累計売却額')
     
     # 日付情報
     first_purchase_date = models.DateField(null=True, blank=True, db_index=True, verbose_name='最初の購入日')
@@ -269,7 +279,58 @@ class StockDiary(models.Model):
                      f"実現損益={self.realized_profit}")
         logger.debug(f"{'='*60}\n")
         
-        self.save()    
+        self._update_cash_only_aggregates()
+
+        self.save()
+
+    def _update_cash_only_aggregates(self):
+        """現物取引のみ（is_margin=False）の集計フィールドを更新（save()は呼ばない）"""
+        cash_transactions = self.transactions.filter(is_margin=False).order_by('transaction_date', 'created_at')
+
+        cash_quantity = Decimal('0')
+        cash_cost = Decimal('0')
+        cash_realized_profit = Decimal('0')
+        cash_bought_quantity = Decimal('0')
+        cash_sold_quantity = Decimal('0')
+        cash_buy_amount = Decimal('0')
+        cash_sell_amount = Decimal('0')
+
+        for transaction in cash_transactions:
+            adjusted_quantity = transaction.quantity
+            adjusted_price = transaction.price
+
+            if transaction.transaction_type == 'buy':
+                buy_amount = adjusted_price * adjusted_quantity
+                cash_cost += buy_amount
+                cash_quantity += adjusted_quantity
+                cash_bought_quantity += adjusted_quantity
+                cash_buy_amount += buy_amount
+            elif transaction.transaction_type == 'sell':
+                if cash_quantity > 0:
+                    avg_price = cash_cost / cash_quantity
+                    sell_quantity = min(adjusted_quantity, cash_quantity)
+                    sell_cost = avg_price * sell_quantity
+                    actual_sell_amount = adjusted_price * sell_quantity
+                    profit = actual_sell_amount - sell_cost
+                    cash_realized_profit += profit
+                    cash_cost -= sell_cost
+                    cash_quantity -= sell_quantity
+                cash_sold_quantity += adjusted_quantity
+                cash_sell_amount += adjusted_price * adjusted_quantity
+
+        cash_avg_price = None
+        if cash_quantity > 0:
+            cash_avg_price = (cash_cost / cash_quantity).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+
+        self.cash_only_current_quantity = cash_quantity.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+        self.cash_only_average_purchase_price = cash_avg_price
+        self.cash_only_total_cost = cash_cost.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+        self.cash_only_realized_profit = cash_realized_profit.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+        self.cash_only_total_bought_quantity = cash_bought_quantity
+        self.cash_only_total_sold_quantity = cash_sold_quantity
+        self.cash_only_total_buy_amount = cash_buy_amount
+        self.cash_only_total_sell_amount = cash_sell_amount
+
     def process_and_save_image(self, image_file):
         """画像を圧縮・処理して保存"""
         try:
@@ -331,67 +392,16 @@ class StockDiary(models.Model):
         return None
 
     def calculate_cash_only_stats(self):
-        """現物取引（is_margin=False）のみの統計を計算"""
-        from decimal import Decimal, ROUND_HALF_UP
-        
-        cash_transactions = self.transactions.filter(is_margin=False).order_by('transaction_date', 'created_at')
-        
-        cash_quantity = Decimal('0')
-        cash_cost = Decimal('0')
-        cash_realized_profit = Decimal('0')
-        cash_bought_quantity = Decimal('0')
-        cash_sold_quantity = Decimal('0')
-        cash_buy_amount = Decimal('0')
-        cash_sell_amount = Decimal('0')
-        
-        for transaction in cash_transactions:
-            # 分割調整を適用
-            adjusted_quantity = transaction.quantity
-            adjusted_price = transaction.price
-                        
-            if transaction.transaction_type == 'buy':
-                # 購入処理
-                buy_amount = adjusted_price * adjusted_quantity
-                cash_cost += buy_amount
-                cash_quantity += adjusted_quantity
-                cash_bought_quantity += adjusted_quantity
-                cash_buy_amount += buy_amount
-                
-            elif transaction.transaction_type == 'sell':
-                # 売却処理
-                if cash_quantity > 0:
-                    avg_price = cash_cost / cash_quantity
-                    sell_quantity = min(adjusted_quantity, cash_quantity)
-                    sell_cost = avg_price * sell_quantity
-                    actual_sell_amount = adjusted_price * sell_quantity
-                    profit = actual_sell_amount - sell_cost
-                    cash_realized_profit += profit
-                    cash_cost -= sell_cost
-                    cash_quantity -= sell_quantity
-                    cash_sold_quantity += adjusted_quantity
-                    cash_sell_amount += adjusted_price * adjusted_quantity
-        
-        # 平均取得単価を計算
-        cash_avg_price = None
-        if cash_quantity > 0:
-            cash_avg_price = (cash_cost / cash_quantity).quantize(
-                Decimal('0.01'), rounding=ROUND_HALF_UP
-            )
-        
-        # 数値の丸め処理
-        cash_quantity = cash_quantity.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-        cash_cost = cash_cost.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-        cash_realized_profit = cash_realized_profit.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-        
+        """現物取引（is_margin=False）のみの統計を返す（キャッシュ済みフィールドを使用）"""
         return {
-            'current_quantity': cash_quantity,
-            'average_purchase_price': cash_avg_price,
-            'total_cost': cash_cost,
-            'realized_profit': cash_realized_profit,
-            'total_bought_quantity': cash_bought_quantity,
-            'total_sold_quantity': cash_sold_quantity,
-            'total_buy_amount': cash_buy_amount,
-            'total_sell_amount': cash_sell_amount,
+            'current_quantity': self.cash_only_current_quantity,
+            'average_purchase_price': self.cash_only_average_purchase_price,
+            'total_cost': self.cash_only_total_cost,
+            'realized_profit': self.cash_only_realized_profit,
+            'total_bought_quantity': self.cash_only_total_bought_quantity,
+            'total_sold_quantity': self.cash_only_total_sold_quantity,
+            'total_buy_amount': self.cash_only_total_buy_amount,
+            'total_sell_amount': self.cash_only_total_sell_amount,
         }
         
     @property

--- a/stockdiary/views_mobile_ux.py
+++ b/stockdiary/views_mobile_ux.py
@@ -16,7 +16,7 @@ from django.urls import reverse
 from django.shortcuts import get_object_or_404
 from decimal import Decimal, InvalidOperation
 
-from .models import StockDiary, Transaction, DiaryNote
+from .models import StockDiary, DiaryNote, Transaction
 from tags.models import Tag
 import logging
 
@@ -28,203 +28,78 @@ logger = logging.getLogger(__name__)
 def quick_create_diary(request):
     """
     クイック記録API（Ajax対応）
-    最小限の入力で日記を作成
-    
-    🆕 修正内容:
-    - 銘柄コード（stock_code）と銘柄名（stock_name_hidden）を分けて取得
-    - 業種・市場情報も自動設定
+    銘柄名とメモのみで日記を作成
     """
     try:
-        # 🆕 銘柄コードと名称を分けて取得
+        # 銘柄コードと名称を取得
         stock_code = request.POST.get('stock_code', '').strip()
         stock_name = request.POST.get('stock_name_hidden', '').strip()
-        
-        # 🔧 後方互換性: stock_nameフィールドから取得を試みる（手動入力の場合）
+
+        # stock_nameフィールドから取得（手動入力の場合）
         if not stock_name:
             stock_name_input = request.POST.get('stock_name', '').strip()
-            # "コード 名称" 形式で入力されている場合はパース
             if stock_name_input:
-                parts = stock_name_input.split(None, 1)  # 最初の空白で分割
+                parts = stock_name_input.split(None, 1)
                 if len(parts) == 2:
                     stock_code = parts[0]
                     stock_name = parts[1]
                 elif len(parts) == 1:
-                    # コードのみの場合
                     stock_name = parts[0]
 
         # 銘柄名がない場合は「メモ」として扱う
         if not stock_name:
             stock_name = f"メモ - {timezone.now().strftime('%Y/%m/%d %H:%M')}"
 
-        # 文字数制限チェック
         if len(stock_name) > 100:
             return JsonResponse({
                 'success': False,
                 'message': '銘柄名は100文字以内で入力してください'
             }, status=400)
-        
+
         if stock_code and len(stock_code) > 50:
             return JsonResponse({
                 'success': False,
                 'message': '銘柄コードは50文字以内で入力してください'
             }, status=400)
 
-        # 🆕 購入情報を取得
-        purchase_price = request.POST.get('purchase_price', '').strip()
-        purchase_quantity = request.POST.get('purchase_quantity', '').strip()
-        purchase_date_str = request.POST.get('purchase_date', '').strip()
-
-        # 🆕 購入価格のバリデーション
-        purchase_price_decimal = None
-        if purchase_price:
-            try:
-                purchase_price_decimal = Decimal(purchase_price)
-                if purchase_price_decimal < 0:
-                    return JsonResponse({
-                        'success': False,
-                        'message': '購入単価は0以上の数値を入力してください'
-                    }, status=400)
-            except (ValueError, InvalidOperation):
-                return JsonResponse({
-                    'success': False,
-                    'message': '購入単価は有効な数値を入力してください'
-                }, status=400)
-
-        # 🆕 購入数量のバリデーション
-        purchase_quantity_int = None
-        if purchase_quantity:
-            try:
-                purchase_quantity_int = int(purchase_quantity)
-                if purchase_quantity_int < 1:
-                    return JsonResponse({
-                        'success': False,
-                        'message': '購入数量は1以上の整数を入力してください'
-                    }, status=400)
-            except ValueError:
-                return JsonResponse({
-                    'success': False,
-                    'message': '購入数量は有効な整数を入力してください'
-                }, status=400)
-
-        # 🆕 購入日のバリデーション
-        purchase_date = None
-        if purchase_date_str:
-            try:
-                from datetime import datetime
-                purchase_date = datetime.strptime(purchase_date_str, '%Y-%m-%d').date()
-            except ValueError:
-                return JsonResponse({
-                    'success': False,
-                    'message': '購入日の形式が正しくありません'
-                }, status=400)
+        # メモ（投資理由フィールドを使用）
+        reason = request.POST.get('reason', '').strip()
+        if reason and len(reason) > 2000:
+            return JsonResponse({
+                'success': False,
+                'message': 'メモは2000文字以内で入力してください'
+            }, status=400)
 
         # 日記作成
         diary = StockDiary(
             user=request.user,
             stock_name=stock_name,
-            stock_symbol=stock_code if stock_code else '',  # 🆕 銘柄コードを設定
+            stock_symbol=stock_code if stock_code else '',
         )
 
-        # 🆕 業種・市場情報を設定
+        # 業種・市場情報を設定（オートコンプリート経由の場合）
         industry = request.POST.get('industry', '').strip()
         market = request.POST.get('market', '').strip()
 
         if industry:
-            diary.sector = industry[:50]  # 最大50文字
+            diary.sector = industry[:50]
 
-        # 市場情報はメモに追記（必要に応じて）
         if market and not diary.memo:
             diary.memo = f"市場: {market}"
 
-        # 任意項目: 投資理由
-        reason = request.POST.get('reason', '').strip()
         if reason:
-            if len(reason) > 2000:
-                return JsonResponse({
-                    'success': False,
-                    'message': '投資理由は2000文字以内で入力してください'
-                }, status=400)
             diary.reason = reason
 
-        # 保存
         diary.save()
 
-        # 🆕 銘柄コードが設定されているが購入価格が未入力の場合、株価APIから自動取得
-        if stock_code and not purchase_price_decimal:
-            try:
-                from .api import get_stock_price
-                from django.http import HttpRequest
-
-                # 株価取得APIを内部的に呼び出し
-                api_request = HttpRequest()
-                api_request.user = request.user
-                api_request.method = 'GET'
-
-                stock_price_response = get_stock_price(api_request, stock_code)
-
-                if stock_price_response.status_code == 200:
-                    import json
-                    price_data = json.loads(stock_price_response.content)
-
-                    if price_data.get('success') and price_data.get('price'):
-                        # 株価を取得できた場合、purchase_price_decimalに設定
-                        purchase_price_decimal = Decimal(str(price_data['price']))
-
-                        logger.info(
-                            f"[quick_create_diary] Auto-fetched stock price: "
-                            f"code={stock_code}, price={purchase_price_decimal}"
-                        )
-            except Exception as e:
-                # 株価取得に失敗してもエラーにはせず、ログ出力のみ
-                logger.warning(
-                    f"[quick_create_diary] Failed to auto-fetch stock price: "
-                    f"code={stock_code}, error={str(e)}"
-                )
-
-        # 🆕 購入情報があれば、Transactionを作成
-        transaction_created = False
-        if purchase_price_decimal is not None and purchase_quantity_int is not None:
-            # 購入日が未指定の場合は今日の日付
-            if not purchase_date:
-                purchase_date = timezone.now().date()
-
-            # Transaction作成
-            transaction = Transaction.objects.create(
-                diary=diary,
-                transaction_type='buy',
-                transaction_date=purchase_date,
-                price=purchase_price_decimal,
-                quantity=purchase_quantity_int,
-                is_margin=False
-            )
-
-            # 日記の集計情報を更新
-            diary.update_aggregates()
-
-            transaction_created = True
-
-            logger.info(
-                f"[quick_create_diary] Created transaction: "
-                f"price={purchase_price_decimal}, quantity={purchase_quantity_int}, date={purchase_date}"
-            )
-
-        # 🆕 ログ出力（デバッグ用）
         logger.info(
-            f"[quick_create_diary] Created diary: "
-            f"code={stock_code}, name={stock_name}, "
-            f"industry={industry}, market={market}, transaction_created={transaction_created}"
+            f"[quick_create_diary] Created diary: code={stock_code}, name={stock_name}"
         )
 
         return JsonResponse({
             'success': True,
             'message': f'クイック記録を作成しました: {stock_name}',
             'diary_id': diary.id,
-            'stock_code': stock_code,
-            'stock_name': stock_name,
-            'transaction_created': transaction_created,
-            'purchase_price': float(purchase_price_decimal) if purchase_price_decimal else None,
-            'purchase_quantity': purchase_quantity_int,
-            'purchase_date': purchase_date.strftime('%Y-%m-%d') if purchase_date else None,
             'redirect_url': reverse('stockdiary:detail', kwargs={'pk': diary.id})
         })
 

--- a/templates/components/quick_record_sheet.html
+++ b/templates/components/quick_record_sheet.html
@@ -26,17 +26,10 @@
       <form id="quickRecordForm" method="post" action="{% url 'stockdiary:quick_create' %}">
         {% csrf_token %}
 
-        <!-- Step インジケーター -->
-        <div class="step-indicator" aria-label="入力ステップ">
-          <span class="step active" aria-label="ステップ1: 銘柄名">1</span>
-          <span class="step" aria-label="ステップ2: 購入情報">2</span>
-          <span class="step" aria-label="ステップ3: 投資理由">3</span>
-        </div>
-
-        <!-- Step 1: 銘柄名のみ（任意） -->
-        <div class="form-step active" data-step="1">
+        <!-- 銘柄名 -->
+        <div class="mb-3">
           <label for="stock_name_quick">
-            銘柄名（任意・メモのみも可）
+            銘柄名（任意）
           </label>
           <div class="input-with-suggestions">
             <input
@@ -59,108 +52,25 @@
           </div>
         </div>
 
-        <!-- Step 2: 購入情報（任意） -->
-        <div class="form-step" data-step="2">
-          <label>購入情報（任意・スキップ可）</label>
-          <p class="text-muted small mb-3">
-            後から詳細ページで追加できます
-          </p>
-
-          <div class="row g-2">
-            <div class="col-6">
-              <label for="purchase_price_quick" class="small">購入単価（円）</label>
-              <input
-                type="number"
-                name="purchase_price"
-                id="purchase_price_quick"
-                class="form-control"
-                placeholder="2500"
-                step="0.01"
-                min="0">
-            </div>
-            <div class="col-6">
-              <label for="purchase_quantity_quick" class="small">購入数量（株）</label>
-              <input
-                type="number"
-                name="purchase_quantity"
-                id="purchase_quantity_quick"
-                class="form-control"
-                placeholder="100"
-                step="1"
-                min="1">
-            </div>
-          </div>
-
-          <div class="mt-3">
-            <label for="purchase_date_quick" class="small">購入日</label>
-            <input
-              type="date"
-              name="purchase_date"
-              id="purchase_date_quick"
-              class="form-control"
-              value="{{ today|date:'Y-m-d' }}">
-          </div>
-        </div>
-
-        <!-- Step 3: 投資理由（任意） -->
-        <div class="form-step" data-step="3">
-          <label for="reason_quick">投資理由（任意・スキップ可）</label>
-          <p class="text-muted small mb-3">
-            後から詳細ページで詳しく記入できます
-          </p>
-
-          <!-- テンプレート選択 -->
-          <div class="mb-3">
-            <label class="small fw-bold mb-2">
-              <i class="bi bi-file-earmark-text me-1"></i>
-              テンプレートを使う（任意）
-            </label>
-            <div class="d-flex flex-wrap gap-2">
-              <button type="button" class="btn btn-sm btn-outline-primary template-btn" data-template="growth">
-                🚀 成長株
-              </button>
-              <button type="button" class="btn btn-sm btn-outline-success template-btn" data-template="dividend">
-                💰 配当
-              </button>
-              <button type="button" class="btn btn-sm btn-outline-info template-btn" data-template="value">
-                📊 バリュー
-              </button>
-              <button type="button" class="btn btn-sm btn-outline-warning template-btn" data-template="swing">
-                📈 スイング
-              </button>
-            </div>
-          </div>
-
+        <!-- メモ -->
+        <div class="mb-3">
+          <label for="reason_quick">メモ（任意）</label>
           <textarea
             name="reason"
             id="reason_quick"
             class="form-control"
-            rows="6"
-            placeholder="購入を検討した理由や注目ポイントを入力...
-
-例:
-・決算が良かった
-・チャートが上昇トレンド
-・配当利回りが高い"
+            rows="5"
+            placeholder="気になるポイントや考察を自由に記録..."
             maxlength="2000"></textarea>
-
-          <div class="form-text small text-muted mt-2">
+          <div class="form-text small text-muted mt-1">
             <i class="bi bi-info-circle me-1"></i>
             2000文字まで入力可能
           </div>
         </div>
 
-        <!-- ナビゲーションボタン -->
-        <div class="step-navigation">
-          <button type="button" class="btn btn-outline" id="prevBtn" style="display:none;">
-            <i class="bi bi-arrow-left me-1"></i>
-            戻る
-          </button>
-          <button type="button" class="btn btn-primary" id="nextBtn">
-            次へ
-            <i class="bi bi-arrow-right ms-1"></i>
-          </button>
-          <button type="submit" class="btn btn-success" id="submitBtn" style="display:none;">
+        <!-- 送信ボタン -->
+        <div class="d-grid">
+          <button type="submit" class="btn btn-success btn-lg" id="submitBtn">
             <i class="bi bi-check-lg me-1"></i>
             保存
           </button>
@@ -170,70 +80,17 @@
   </div>
 </div>
 
-{% comment %}
-JavaScript初期化
-※ bottom-sheet.js が読み込まれていることが前提
-{% endcomment %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  // テンプレートボタンのイベント
-  const templateBtns = document.querySelectorAll('.template-btn');
-  const reasonTextarea = document.getElementById('reason_quick');
-
-  templateBtns.forEach(btn => {
-    btn.addEventListener('click', function() {
-      const template = this.dataset.template;
-
-      // アクティブ状態を切り替え
-      templateBtns.forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
-
-      // テンプレートテキストを挿入
-      const templates = {
-        'growth': `## 注目理由
-- 業績の成長性が高い
-- 市場シェア拡大中
-
-## リスク
-- 割高感に注意`,
-        'dividend': `## 配当情報
-- 配当利回り: %
-- 配当性向: %
-
-## 安定性
-- 業績安定`,
-        'value': `## バリュエーション
-- PER:
-- PBR:
-- 割安と判断した理由: `,
-        'swing': `## エントリー条件
-- テクニカル指標:
-- 目標価格:
-- 損切りライン: `
-      };
-
-      if (templates[template]) {
-        reasonTextarea.value = templates[template];
-
-        // 触覚フィードバック
-        if (navigator.vibrate) {
-          navigator.vibrate(10);
-        }
-      }
-    });
-  });
-
   // フォーム送信時の処理
   const form = document.getElementById('quickRecordForm');
   form.addEventListener('submit', function(e) {
     e.preventDefault();
 
-    // ボタンを無効化（二重送信防止）
     const submitBtn = document.getElementById('submitBtn');
     submitBtn.disabled = true;
     submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>保存中...';
 
-    // フォーム送信
     const formData = new FormData(form);
 
     fetch(form.action, {
@@ -246,18 +103,13 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(response => response.json())
     .then(data => {
       if (data.success) {
-        // 成功時の処理
         if (navigator.vibrate) {
-          navigator.vibrate([10, 5, 10]); // 成功の振動
+          navigator.vibrate([10, 5, 10]);
         }
 
-        // ボトムシートを閉じる
         closeBottomSheet('quickRecordSheet');
-
-        // 成功メッセージを表示
         showToast('success', 'クイック記録を作成しました');
 
-        // ページをリロードまたは日記を追加
         if (data.redirect_url) {
           setTimeout(() => {
             window.location.href = data.redirect_url;
@@ -268,7 +120,6 @@ document.addEventListener('DOMContentLoaded', function() {
           }, 500);
         }
       } else {
-        // エラー時の処理
         showToast('error', data.message || '保存に失敗しました');
         submitBtn.disabled = false;
         submitBtn.innerHTML = '<i class="bi bi-check-lg me-1"></i> 保存';
@@ -283,10 +134,7 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 
-// トースト通知（簡易版）
 function showToast(type, message) {
-  // 既存のトースト通知システムがあればそれを使用
-  // なければシンプルなalertで代替
   if (typeof window.showNotification === 'function') {
     window.showNotification(message, type);
   } else {


### PR DESCRIPTION
## 修正内容

### 1. cash_only_* フィールドのNULL制約エラー解消 (models.py)
- DBに存在する cash_only_current_quantity 等8フィールドをモデルに追加
  （過去のコミットでDBに追加後、モデルが差し戻されてINSERT失敗していた）
- _update_cash_only_aggregates() メソッドを追加し update_aggregates() から呼び出し
- calculate_cash_only_stats() をDB保存済みフィールドを返す形式に変更（O(n)→O(1)）

### 2. クイック日記のシンプル化 (quick_record_sheet.html)
- 3ステップ構成 → 1画面構成に変更
- 購入情報（単価・数量・購入日）を削除
- テンプレートボタン（成長株・配当・バリュー・スイング）を削除
- 銘柄名（任意）とメモ（任意）のみのシンプルな入力フォームに

### 3. バックエンドの購入情報処理を削除 (views_mobile_ux.py)
- quick_create_diary から購入情報のバリデーション・Transaction作成処理を削除
- 株価自動取得処理も削除
- 銘柄名＋メモ保存のみのシンプルな実装に

https://claude.ai/code/session_01BRgYCXjRjGJrPNpo2LnEww