### PR TITLE
feat: 日記詳細画面に関連グラフ可視化を追加

### DIFF
--- a/static/js/diary-detail-graph.js
+++ b/static/js/diary-detail-graph.js
@@ -1,0 +1,309 @@
+/**
+ * diary-detail-graph.js
+ * 日記詳細画面用：D3.js force-directed 埋め込みグラフ
+ *
+ * 使い方:
+ *   window.DIARY_DETAIL_GRAPH_API = "/stockdiary/api/diary/<id>/graph/";
+ *   window.DIARY_FOCAL_ID = <id>;
+ */
+
+(function () {
+  'use strict';
+
+  // ── カラー定数（diary-graph.js と同じ値） ──────────────────────────
+  const STATUS_COLOR = {
+    holding: '#10b981',
+    sold:    '#ef4444',
+    memo:    '#9ca3af',
+  };
+  const HUB_COLOR = {
+    tag:     '#7c3aed',
+    sector:  '#d97706',
+    hashtag: '#0ea5e9',
+  };
+  const EDGE_COLOR = {
+    manual:  '#94a3b8',
+    tag:     '#a78bfa',
+    sector:  '#fb923c',
+    hashtag: '#38bdf8',
+    mention: '#f59e0b',
+  };
+
+  // ── ノード半径 ────────────────────────────────────────────────────────
+  function nodeRadius(node, isFocal) {
+    if (isFocal) return 22;
+    if (node.node_type !== 'diary') return 12;
+    return Math.max(8, Math.min(18, 8 + (node.link_count || 0) * 1.5));
+  }
+
+  // ── メインクラス ─────────────────────────────────────────────────────
+  class DiaryDetailGraph {
+    constructor(apiUrl, focalId) {
+      this.apiUrl  = apiUrl;
+      this.focalId = focalId;
+
+      this.svg        = d3.select('#detail-graph-svg');
+      this.loading    = document.getElementById('detail-graph-loading');
+      this.emptyMsg   = document.getElementById('detail-graph-empty');
+      this.tooltip    = document.getElementById('detail-graph-tooltip');
+      this.container  = document.getElementById('detail-graph-container');
+
+      this.simulation = null;
+
+      this._bindEdgeModeControls();
+      this._fetchAndRender(this._getEdgeModes());
+    }
+
+    // ── エッジモードチェックボックスを取得 ─────────────────────────────
+    _getEdgeModes() {
+      const checked = document.querySelectorAll('.detail-edge-check:checked');
+      const modes = Array.from(checked).map(el => el.value);
+      return modes.length ? modes : ['manual', 'tag', 'sector', 'hashtag', 'mention'];
+    }
+
+    // ── チェックボックスのイベント登録 ────────────────────────────────
+    _bindEdgeModeControls() {
+      document.querySelectorAll('.detail-edge-check').forEach(el => {
+        el.addEventListener('change', () => {
+          if (this.simulation) this.simulation.stop();
+          this._fetchAndRender(this._getEdgeModes());
+        });
+      });
+    }
+
+    // ── API 呼び出し & 描画 ────────────────────────────────────────────
+    _fetchAndRender(edgeModes) {
+      this._showLoading(true);
+      // 前回の描画をクリア
+      this.svg.selectAll('*').remove();
+
+      const url = `${this.apiUrl}?edge_modes=${edgeModes.join(',')}`;
+      fetch(url, { credentials: 'same-origin' })
+        .then(r => r.json())
+        .then(data => {
+          this._showLoading(false);
+          if (!data.nodes || data.nodes.length === 0) {
+            this._showEmpty(true);
+            return;
+          }
+          this._showEmpty(false);
+          this._render(data);
+        })
+        .catch(() => {
+          this._showLoading(false);
+          this._showEmpty(true);
+        });
+    }
+
+    // ── D3 グラフ描画 ─────────────────────────────────────────────────
+    _render(data) {
+      const width  = this.container.clientWidth  || 400;
+      const height = this.container.clientHeight || 280;
+
+      // SVG に zoom レイヤーを設定
+      const zoom = d3.zoom()
+        .scaleExtent([0.3, 4])
+        .on('zoom', (event) => g.attr('transform', event.transform));
+
+      this.svg
+        .attr('width', width)
+        .attr('height', height)
+        .call(zoom);
+
+      const g = this.svg.append('g');
+
+      // ノード・エッジをコピー（D3 がプロパティを付加するため）
+      const nodes = data.nodes.map(d => ({ ...d }));
+      const edges = data.edges.map(d => ({ ...d }));
+
+      // ── force simulation ────────────────────────────────────────────
+      const sim = d3.forceSimulation(nodes)
+        .force('link',
+          d3.forceLink(edges)
+            .id(d => d.id)
+            .distance(d => (d.edge_type === 'manual' ? 90 : 110))
+        )
+        .force('charge', d3.forceManyBody().strength(-220))
+        .force('center', d3.forceCenter(width / 2, height / 2))
+        .force('collision',
+          d3.forceCollide(d =>
+            nodeRadius(d, d.id === this.focalId) * 1.8
+          )
+        );
+
+      this.simulation = sim;
+
+      // フォーカルノードを初期位置で中心に固定（後でリリース）
+      const focalNode = nodes.find(n => n.id === this.focalId);
+      if (focalNode) {
+        focalNode.fx = width / 2;
+        focalNode.fy = height / 2;
+        // 少し落ち着いたら固定を外す
+        setTimeout(() => {
+          if (focalNode) { focalNode.fx = null; focalNode.fy = null; }
+          sim.alpha(0.3).restart();
+        }, 800);
+      }
+
+      // ── エッジ描画 ─────────────────────────────────────────────────
+      const link = g.append('g').attr('class', 'detail-graph-links')
+        .selectAll('line')
+        .data(edges)
+        .join('line')
+          .attr('stroke', d => EDGE_COLOR[d.edge_type] || '#aaa')
+          .attr('stroke-width', 1.5)
+          .attr('stroke-opacity', 0.65);
+
+      // ── ノード描画 ─────────────────────────────────────────────────
+      const node = g.append('g').attr('class', 'detail-graph-nodes')
+        .selectAll('g')
+        .data(nodes)
+        .join('g')
+          .attr('class', 'detail-graph-node')
+          .style('cursor', d =>
+            d.id === this.focalId ? 'default' : (d.node_type === 'diary' ? 'pointer' : 'default')
+          )
+          .call(
+            d3.drag()
+              .on('start', (event, d) => {
+                if (!event.active) sim.alphaTarget(0.3).restart();
+                d.fx = d.x; d.fy = d.y;
+              })
+              .on('drag', (event, d) => {
+                d.fx = event.x; d.fy = event.y;
+              })
+              .on('end', (event, d) => {
+                if (!event.active) sim.alphaTarget(0);
+                // ダブルクリックで固定解除（通常ドラッグは固定のまま）
+              })
+          );
+
+      // 円（全ノード共通）
+      node.append('circle')
+        .attr('r', d => nodeRadius(d, d.id === this.focalId))
+        .attr('fill', d => {
+          if (d.node_type !== 'diary') return HUB_COLOR[d.node_type] || '#999';
+          return STATUS_COLOR[d.status] || '#9ca3af';
+        })
+        .attr('stroke', d => d.id === this.focalId ? '#f59e0b' : 'rgba(255,255,255,0.5)')
+        .attr('stroke-width', d => d.id === this.focalId ? 3 : 1);
+
+      // フォーカルノードに外枠リング
+      node.filter(d => d.id === this.focalId)
+        .append('circle')
+          .attr('r', d => nodeRadius(d, true) + 5)
+          .attr('fill', 'none')
+          .attr('stroke', '#f59e0b')
+          .attr('stroke-width', 2)
+          .attr('stroke-dasharray', '4,2')
+          .attr('stroke-opacity', 0.8);
+
+      // ラベル（銘柄コードまたはハブ名）
+      node.append('text')
+        .attr('dy', d => nodeRadius(d, d.id === this.focalId) + 10)
+        .attr('text-anchor', 'middle')
+        .attr('font-size', d => d.id === this.focalId ? '11px' : '9px')
+        .attr('font-weight', d => d.id === this.focalId ? 'bold' : 'normal')
+        .attr('fill', 'var(--bs-body-color, #333)')
+        .attr('pointer-events', 'none')
+        .text(d => {
+          if (d.node_type !== 'diary') return d.tag_name || '';
+          return d.stock_symbol || d.stock_name || '';
+        });
+
+      // ── インタラクション ────────────────────────────────────────────
+      node
+        .on('mouseover', (event, d) => this._showTooltip(event, d))
+        .on('mousemove', (event) => this._moveTooltip(event))
+        .on('mouseout',  () => this._hideTooltip())
+        .on('click', (event, d) => {
+          if (d.node_type === 'diary' && d.id !== this.focalId && d.url) {
+            window.location.href = d.url;
+          }
+        });
+
+      // ダブルクリックで固定解除
+      node.on('dblclick', (event, d) => {
+        d.fx = null; d.fy = null;
+        sim.alpha(0.3).restart();
+      });
+
+      // ── tick ────────────────────────────────────────────────────────
+      sim.on('tick', () => {
+        link
+          .attr('x1', d => d.source.x)
+          .attr('y1', d => d.source.y)
+          .attr('x2', d => d.target.x)
+          .attr('y2', d => d.target.y);
+
+        node.attr('transform', d => `translate(${d.x},${d.y})`);
+      });
+    }
+
+    // ── ツールチップ ────────────────────────────────────────────────
+    _showTooltip(event, d) {
+      let html = '';
+      if (d.node_type === 'diary') {
+        const isFocal = d.id === this.focalId;
+        const statusLabel = { holding: '保有中', sold: '売却済', memo: 'メモ' };
+        const statusColor = STATUS_COLOR[d.status] || '#aaa';
+        html = `
+          <div style="font-weight:bold;margin-bottom:2px;">
+            ${isFocal ? '★ ' : ''}${d.stock_name || ''}
+          </div>
+          ${d.stock_symbol ? `<div style="color:#aaa;font-size:0.68rem;">${d.stock_symbol}</div>` : ''}
+          <div style="margin-top:3px;">
+            <span style="background:${statusColor};border-radius:3px;padding:1px 5px;font-size:0.68rem;">
+              ${statusLabel[d.status] || d.status}
+            </span>
+          </div>
+          ${d.realized_profit !== undefined
+            ? `<div style="margin-top:3px;color:${d.realized_profit >= 0 ? '#6ee7b7' : '#fca5a5'};">
+                損益: ${d.realized_profit >= 0 ? '+' : ''}${d.realized_profit.toLocaleString()}円
+              </div>`
+            : ''
+          }`;
+      } else {
+        const typeLabel = { tag: 'タグ', sector: '業種', hashtag: 'ハッシュタグ' };
+        html = `
+          <div style="font-weight:bold;">${d.tag_name || ''}</div>
+          <div style="color:#aaa;font-size:0.68rem;">${typeLabel[d.node_type] || d.node_type}</div>`;
+      }
+
+      this.tooltip.innerHTML = html;
+      this.tooltip.style.display = 'block';
+      this._moveTooltip(event);
+    }
+
+    _moveTooltip(event) {
+      const x = event.clientX + 12;
+      const y = event.clientY - 10;
+      const tw = this.tooltip.offsetWidth;
+      const th = this.tooltip.offsetHeight;
+      this.tooltip.style.left = (x + tw > window.innerWidth  ? x - tw - 20 : x) + 'px';
+      this.tooltip.style.top  = (y + th > window.innerHeight ? y - th      : y) + 'px';
+    }
+
+    _hideTooltip() {
+      this.tooltip.style.display = 'none';
+    }
+
+    // ── ローディング/空表示 ─────────────────────────────────────────
+    _showLoading(show) {
+      this.loading.style.display = show ? 'flex' : 'none';
+    }
+
+    _showEmpty(show) {
+      this.emptyMsg.style.display = show ? 'flex' : 'none';
+    }
+  }
+
+  // ── 初期化 ────────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', function () {
+    const apiUrl  = window.DIARY_DETAIL_GRAPH_API;
+    const focalId = window.DIARY_FOCAL_ID;
+    if (apiUrl && focalId !== undefined && typeof d3 !== 'undefined') {
+      new DiaryDetailGraph(apiUrl, focalId);
+    }
+  });
+})();

--- a/stockdiary/api_views.py
+++ b/stockdiary/api_views.py
@@ -16,7 +16,7 @@ from .models import (
 from .utils import (
     extract_hashtags, get_all_hashtags_from_queryset, search_diaries_by_hashtag,
     get_tag_graph_data, get_sector_graph_data, get_hashtag_graph_data,
-    get_mention_graph_data,
+    get_mention_graph_data, extract_stock_mentions,
 )
 import json
 from pywebpush import webpush, WebPushException
@@ -812,3 +812,176 @@ def _diary_status(diary) -> str:
     elif diary.transaction_count > 0:
         return 'sold'
     return 'memo'
+
+
+@login_required
+@require_http_methods(["GET"])
+def diary_detail_graph_data(request, diary_id):
+    """日記詳細画面用：特定の日記を中心とした関連グラフデータを返す。
+
+    Query Parameters:
+        edge_modes: カンマ区切りのモード列（manual,tag,sector,hashtag,mention）
+                    デフォルトは全モード
+
+    Returns:
+        {
+          nodes: [...],  # diary ノード + ハブノード
+          edges: [...],
+          meta: { total_nodes, total_edges, modes, focal_diary_id }
+        }
+        diary ノードには is_focal: true/false フラグを含む
+    """
+    try:
+        focal = get_object_or_404(StockDiary, id=diary_id, user=request.user)
+
+        VALID_MODES = {'manual', 'tag', 'sector', 'hashtag', 'mention'}
+        raw = request.GET.get('edge_modes', 'manual,tag,sector,hashtag,mention').strip()
+        edge_modes = [m.strip() for m in raw.split(',') if m.strip() in VALID_MODES]
+        if not edge_modes:
+            edge_modes = ['manual', 'tag', 'sector', 'hashtag', 'mention']
+
+        # ── 近傍日記IDを収集 ──────────────────────────────────────────
+        neighbor_ids = set()
+
+        # 手動リンク（両方向）
+        manual_linked_ids = set(focal.linked_diaries.values_list('id', flat=True))
+        manual_from_ids = set(focal.linked_from.values_list('id', flat=True))
+        if 'manual' in edge_modes:
+            neighbor_ids |= manual_linked_ids | manual_from_ids
+
+        # 同一銘柄コードの日記（常に含める）
+        if focal.stock_symbol:
+            same_symbol_ids = set(
+                StockDiary.objects.filter(
+                    user=request.user,
+                    stock_symbol=focal.stock_symbol,
+                ).exclude(id=focal.id).values_list('id', flat=True)
+            )
+            neighbor_ids |= same_symbol_ids
+
+        # テキスト内言及銘柄の日記
+        if 'mention' in edge_modes:
+            search_text = ' '.join(filter(None, [focal.memo, focal.reason]))
+            mentioned_codes = extract_stock_mentions(search_text)
+            if mentioned_codes:
+                mentioned_ids = set(
+                    StockDiary.objects.filter(
+                        user=request.user,
+                        stock_symbol__in=mentioned_codes,
+                    ).exclude(id=focal.id).values_list('id', flat=True)
+                )
+                neighbor_ids |= mentioned_ids
+
+        # ── 全ノード日記を取得 ──────────────────────────────────────────
+        all_diary_ids = {focal.id} | neighbor_ids
+        all_diaries = list(
+            StockDiary.objects.filter(id__in=all_diary_ids)
+            .prefetch_related('tags')
+            .only(
+                'id', 'stock_name', 'stock_symbol', 'sector',
+                'realized_profit', 'current_quantity', 'transaction_count',
+                'reason', 'memo',
+            )
+        )
+
+        diary_nodes_map = {}
+        hub_nodes_map = {}
+        all_edges = []
+
+        for d in all_diaries:
+            diary_nodes_map[d.id] = {
+                'id': d.id,
+                'node_type': 'diary',
+                'stock_name': d.stock_name,
+                'stock_symbol': d.stock_symbol or '',
+                'status': _diary_status(d),
+                'sector': d.sector or '未分類',
+                'realized_profit': float(d.realized_profit),
+                'link_count': 0,
+                'url': f'/stockdiary/{d.id}/',
+                'is_primary': True,
+                'is_focal': d.id == focal.id,
+            }
+
+        # ── エッジ構築 ──────────────────────────────────────────────────
+        # manual エッジ
+        if 'manual' in edge_modes:
+            edge_set = set()
+            for linked_id in manual_linked_ids:
+                if linked_id in diary_nodes_map:
+                    key = (focal.id, linked_id)
+                    if key not in edge_set:
+                        edge_set.add(key)
+                        all_edges.append({'source': focal.id, 'target': linked_id, 'edge_type': 'manual'})
+            for linked_id in manual_from_ids:
+                if linked_id in diary_nodes_map:
+                    key = tuple(sorted([focal.id, linked_id]))
+                    if key not in edge_set:
+                        edge_set.add(key)
+                        all_edges.append({'source': linked_id, 'target': focal.id, 'edge_type': 'manual'})
+
+        # tag ハブノード（フォーカル日記のタグのみ）
+        if 'tag' in edge_modes:
+            focal_list = [d for d in all_diaries if d.id == focal.id]
+            hub_data = get_tag_graph_data(focal_list)
+            for hub in hub_data['tag_nodes']:
+                hub['link_count'] = hub.get('diary_count', 0)
+                hub_nodes_map[hub['id']] = hub
+            all_edges.extend(hub_data['edges'])
+
+        # sector ハブノード（フォーカル日記の業種のみ）
+        if 'sector' in edge_modes and focal.sector:
+            sector_id = f'sec_{focal.sector}'
+            hub_nodes_map[sector_id] = {
+                'id': sector_id,
+                'node_type': 'sector',
+                'tag_name': focal.sector,
+                'diary_count': 1,
+                'link_count': 1,
+            }
+            all_edges.append({'source': focal.id, 'target': sector_id, 'edge_type': 'sector'})
+
+        # hashtag ハブノード（フォーカル日記のハッシュタグのみ）
+        if 'hashtag' in edge_modes:
+            focal_list = [d for d in all_diaries if d.id == focal.id]
+            hub_data = get_hashtag_graph_data(focal_list)
+            for hub in hub_data['hashtag_nodes']:
+                hub['link_count'] = hub.get('diary_count', 0)
+                hub_nodes_map[hub['id']] = hub
+            all_edges.extend(hub_data['edges'])
+
+        # mention エッジ（フォーカル日記のテキスト内言及）
+        if 'mention' in edge_modes:
+            symbol_to_id = {d.stock_symbol: d.id for d in all_diaries if d.stock_symbol}
+            focal_list = [d for d in all_diaries if d.id == focal.id]
+            mention_data = get_mention_graph_data(focal_list, symbol_to_id)
+            all_edges.extend(mention_data['edges'])
+
+        # ── link_count 集計 ──────────────────────────────────────────────
+        link_count_map = {}
+        for e in all_edges:
+            for key in ('source', 'target'):
+                v = e[key]
+                if isinstance(v, int):
+                    link_count_map[v] = link_count_map.get(v, 0) + 1
+
+        for nid, node in diary_nodes_map.items():
+            node['link_count'] = link_count_map.get(nid, 0)
+
+        all_nodes = list(diary_nodes_map.values()) + list(hub_nodes_map.values())
+
+        return JsonResponse({
+            'nodes': all_nodes,
+            'edges': all_edges,
+            'meta': {
+                'total_nodes': len(all_nodes),
+                'total_edges': len(all_edges),
+                'modes': edge_modes,
+                'focal_diary_id': focal.id,
+            },
+        })
+
+    except Exception as e:
+        logger = logging.getLogger(__name__)
+        logger.error(f"diary_detail_graph_data error: {traceback.format_exc()}")
+        return JsonResponse({'success': False, 'error': str(e)}, status=500)

--- a/stockdiary/templates/stockdiary/detail.html
+++ b/stockdiary/templates/stockdiary/detail.html
@@ -1686,6 +1686,56 @@
             </div>
           </div>
 
+          <!-- 関連グラフセクション -->
+          <div class="info-card mobile-optimized" style="margin-bottom: 1rem;">
+            <div class="info-card-title d-flex justify-content-between align-items-center flex-wrap gap-1">
+              <span><i class="bi bi-diagram-3"></i> 関連グラフ</span>
+              <div class="d-flex flex-wrap gap-1 align-items-center">
+                <label class="badge bg-light text-dark border" style="cursor:pointer;font-weight:normal;font-size:0.65rem;user-select:none;">
+                  <input type="checkbox" class="detail-edge-check" value="manual" checked style="vertical-align:middle;"> 手動
+                </label>
+                <label class="badge bg-light text-dark border" style="cursor:pointer;font-weight:normal;font-size:0.65rem;user-select:none;">
+                  <input type="checkbox" class="detail-edge-check" value="tag" checked style="vertical-align:middle;"> タグ
+                </label>
+                <label class="badge bg-light text-dark border" style="cursor:pointer;font-weight:normal;font-size:0.65rem;user-select:none;">
+                  <input type="checkbox" class="detail-edge-check" value="sector" checked style="vertical-align:middle;"> 業種
+                </label>
+                <label class="badge bg-light text-dark border" style="cursor:pointer;font-weight:normal;font-size:0.65rem;user-select:none;">
+                  <input type="checkbox" class="detail-edge-check" value="hashtag" checked style="vertical-align:middle;"> HT
+                </label>
+                <label class="badge bg-light text-dark border" style="cursor:pointer;font-weight:normal;font-size:0.65rem;user-select:none;">
+                  <input type="checkbox" class="detail-edge-check" value="mention" checked style="vertical-align:middle;"> 言及
+                </label>
+                <a href="{% url 'stockdiary:diary_graph' %}"
+                   class="btn btn-sm btn-outline-secondary"
+                   style="padding:0.1rem 0.4rem;font-size:0.7rem;"
+                   title="全体グラフを表示">
+                  <i class="bi bi-arrows-fullscreen"></i>
+                </a>
+              </div>
+            </div>
+            <!-- グラフ描画エリア -->
+            <div id="detail-graph-container"
+                 style="position:relative;height:280px;border-radius:0.4rem;overflow:hidden;background:var(--bs-body-bg,#f8f9fa);margin-top:0.5rem;">
+              <svg id="detail-graph-svg" width="100%" height="100%"></svg>
+              <!-- ローディング -->
+              <div id="detail-graph-loading"
+                   style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:inherit;">
+                <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                  <span class="visually-hidden">読み込み中…</span>
+                </div>
+              </div>
+              <!-- 空メッセージ -->
+              <div id="detail-graph-empty"
+                   style="display:none;position:absolute;inset:0;align-items:center;justify-content:center;">
+                <p class="text-muted small mb-0">関連日記がありません</p>
+              </div>
+            </div>
+            <!-- ツールチップ（全ページ共通・fixed配置） -->
+            <div id="detail-graph-tooltip"
+                 style="display:none;position:fixed;background:rgba(0,0,0,0.82);color:#fff;padding:5px 9px;border-radius:5px;font-size:0.72rem;pointer-events:none;z-index:9999;max-width:200px;line-height:1.4;"></div>
+          </div>
+
           <!-- 関連日記セクション -->
           <div class="info-card mobile-optimized" style="margin-bottom: 1rem;">
             <div class="info-card-title d-flex justify-content-between align-items-center">
@@ -2027,6 +2077,13 @@
 
 {% block scripts %}
 {{ block.super }}
+<!-- D3.js（関連グラフ用） -->
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+<script>
+  window.DIARY_DETAIL_GRAPH_API = "{% url 'stockdiary:api_diary_detail_graph' diary.pk %}";
+  window.DIARY_FOCAL_ID = {{ diary.pk }};
+</script>
+<script src="{% static 'js/diary-detail-graph.js' %}"></script>
 <script src="{% static 'js/diary-detail.js' %}"></script>
 <script src="{% static 'js/diary-detail-tabs.js' %}"></script>
 <script src="{% static 'js/notifications.js' %}"></script>

--- a/stockdiary/urls.py
+++ b/stockdiary/urls.py
@@ -101,6 +101,7 @@ urlpatterns = [
     path('api/diary/<int:diary_id>/related/search/', api_views.search_related_diaries, name='api_related_search'),
     path('api/diary/<int:diary_id>/related/add/', api_views.add_related_diary, name='api_related_add'),
     path('api/diary/<int:diary_id>/related/<int:related_id>/remove/', api_views.remove_related_diary, name='api_related_remove'),
+    path('api/diary/<int:diary_id>/graph/', api_views.diary_detail_graph_data, name='api_diary_detail_graph'),
 
     # 銘柄一覧
     path('stocks/', views.StockListView.as_view(), name='stock_list'),


### PR DESCRIPTION
- 新APIエンドポイント GET /api/diary/<id>/graph/ を追加
  - フォーカル日記を中心に、手動リンク・同一銘柄・
    テキスト言及・タグ・業種・ハッシュタグを含む近傍グラフを返す
  - フォーカル日記に is_focal: true フラグを付与
- urls.py に api_diary_detail_graph パターンを追加
- static/js/diary-detail-graph.js を新規作成
  - D3.js v7 force-directed グラフ（埋め込み用）
  - フォーカルノードをゴールド外枠＋大きいサイズで強調表示
  - エッジモード（手動/タグ/業種/HT/言及）チェックボックスで切替
  - ホバーでツールチップ表示、クリックで詳細ページへ遷移
- detail.html の関連日記セクション上部に「関連グラフ」カードを追加
  - D3.js CDN と diary-detail-graph.js を読み込む

https://claude.ai/code/session_016Zp4VKhmMkuMeNNyiTJxiT