### PR TITLE
fix: テンプレートのデザインを統一・ブランドカラーに刷新

### DIFF
--- a/earnings_analysis/templates/earnings_analysis/base.html
+++ b/earnings_analysis/templates/earnings_analysis/base.html
@@ -37,8 +37,9 @@
 
     <!-- 2. レイアウト -->
     <link rel="stylesheet" href="{% static 'css/2-layouts/tdnet-reports.css' %}?v={{ STATIC_VERSION }}">
-    
-    
+    <link rel="stylesheet" href="{% static 'css/2-layouts/analysis-template.css' %}?v={{ STATIC_VERSION }}">
+
+
     {% block extra_css %}{% endblock %}
     
     <!-- PWA Meta Tags -->

--- a/earnings_analysis/templates/earnings_analysis/financial/result.html
+++ b/earnings_analysis/templates/earnings_analysis/financial/result.html
@@ -5,6 +5,18 @@
 
 {% block title %}財務分析結果 - {{ document.company_name }} -コポモ{% endblock %}
 
+{% block extra_css %}
+<style>
+/* Bootstrapのprimary変数をブランドカラーに統一 */
+:root {
+    --bs-primary: #4072B3;
+    --bs-primary-rgb: 64, 114, 179;
+    --bs-primary-bg-subtle: #f0f5fa;
+    --bs-primary-border-subtle: #dce7f4;
+}
+</style>
+{% endblock %}
+
 {% block breadcrumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">

--- a/earnings_analysis/templates/earnings_analysis/sentiment/result.html
+++ b/earnings_analysis/templates/earnings_analysis/sentiment/result.html
@@ -7,51 +7,7 @@
 {% block title %}感情分析結果 - {{ document.company_name }} - コポモ{% endblock %}
 
 {% block extra_css %}
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
-
 <style>
-:root {
-    --primary-500: #3b82f6;
-    --primary-600: #2563eb;
-    --primary-700: #1d4ed8;
-    --primary-100: #dbeafe;
-    --primary-50: #eff6ff;
-    --success-500: #10b981;
-    --success-600: #059669;
-    --success-100: #d1fae5;
-    --success-50: #ecfdf5;
-    --warning-500: #f59e0b;
-    --warning-600: #d97706;
-    --warning-100: #fef3c7;
-    --warning-50: #fffbeb;
-    --danger-500: #ef4444;
-    --danger-600: #dc2626;
-    --danger-100: #fee2e2;
-    --danger-50: #fef2f2;
-    --info-500: #8b5cf6;
-    --info-100: #ede9fe;
-    --gray-50: #f9fafb;
-    --gray-100: #f3f4f6;
-    --gray-200: #e5e7eb;
-    --gray-300: #d1d5db;
-    --gray-400: #9ca3af;
-    --gray-500: #6b7280;
-    --gray-600: #4b5563;
-    --gray-700: #374151;
-    --gray-800: #1f2937;
-    --gray-900: #111827;
-    --radius-sm: 0.375rem;
-    --radius-md: 0.5rem;
-    --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
-    --radius-2xl: 1.5rem;
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-}
-
 body {
     font-family: 'Noto Sans JP', sans-serif;
     background: var(--gray-50);

--- a/earnings_analysis/templates/earnings_analysis/simple_document_detail.html
+++ b/earnings_analysis/templates/earnings_analysis/simple_document_detail.html
@@ -4,52 +4,7 @@
 {% block title %}{{ document.company_name }} - コポモ{% endblock %}
 
 {% block extra_css %}
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
-
 <style>
-:root {
-    --primary-500: #3b82f6;
-    --primary-600: #2563eb;
-    --primary-700: #1d4ed8;
-    --primary-100: #dbeafe;
-    --primary-50: #eff6ff;
-    --success-500: #10b981;
-    --success-600: #059669;
-    --success-100: #d1fae5;
-    --success-50: #ecfdf5;
-    --warning-500: #f59e0b;
-    --warning-600: #d97706;
-    --warning-100: #fef3c7;
-    --warning-50: #fffbeb;
-    --danger-500: #ef4444;
-    --danger-600: #dc2626;
-    --danger-100: #fee2e2;
-    --danger-50: #fef2f2;
-    --info-500: #8b5cf6;
-    --info-100: #ede9fe;
-    --info-50: #f5f3ff;
-    --gray-50: #f9fafb;
-    --gray-100: #f3f4f6;
-    --gray-200: #e5e7eb;
-    --gray-300: #d1d5db;
-    --gray-400: #9ca3af;
-    --gray-500: #6b7280;
-    --gray-600: #4b5563;
-    --gray-700: #374151;
-    --gray-800: #1f2937;
-    --gray-900: #111827;
-    --radius-md: 0.5rem;
-    --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
-    --radius-2xl: 1.5rem;
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1);
-}
-
 body {
     font-family: 'Noto Sans JP', sans-serif;
     background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
@@ -90,17 +45,7 @@ body {
     color: var(--gray-500);
 }
 
-/* ドキュメントヘッダー */
-.document-header {
-    background: linear-gradient(135deg, var(--primary-600) 0%, #4f46e5 50%, #7c3aed 100%);
-    color: white;
-    padding: 2rem 1.5rem;
-    border-radius: var(--radius-2xl);
-    margin-bottom: 2rem;
-    position: relative;
-    overflow: hidden;
-}
-
+/* ドキュメントヘッダー装飾（グラデーション・サイズはanalysis-template.cssで定義） */
 .document-header::before {
     content: '';
     position: absolute;
@@ -110,12 +55,6 @@ body {
     height: 200%;
     background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 60%);
     pointer-events: none;
-}
-
-@media (min-width: 768px) {
-    .document-header {
-        padding: 2.5rem 2rem;
-    }
 }
 
 .document-header-content {

--- a/static/css/2-layouts/analysis-template.css
+++ b/static/css/2-layouts/analysis-template.css
@@ -29,8 +29,8 @@
   --at-border: var(--bg-300);
   --at-border-light: var(--bg-200);
 
-  --at-primary: var(--accent-200);
-  --at-primary-dark: var(--accent-100);
+  --at-primary: var(--primary-600, #4072B3);
+  --at-primary-dark: var(--primary-700, #2d5a8a);
   --at-success: #10b981;
   --at-warning: #f59e0b;
   --at-danger: #ef4444;
@@ -143,7 +143,7 @@
 
 /* ========== Report Header ========== */
 .at-report-header {
-  background: linear-gradient(135deg, var(--dm-primary), #2563eb);
+  background: linear-gradient(135deg, var(--primary-700, #2d5a8a), var(--primary-600, #4072B3));
   color: white;
   padding: 1.25rem 1rem;
   border-radius: 12px;
@@ -1134,6 +1134,93 @@
 .at-btn-icon.danger:hover {
   background-color: rgba(239, 68, 68, 0.1);
   border-color: var(--at-danger);
+}
+
+/* ========================================
+   Score Display - 財務・感情分析結果で共有
+   ======================================== */
+.score-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 180px;
+  aspect-ratio: 1;
+  border-radius: var(--radius-xl, 1rem);
+  margin: 0 auto;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.score-number {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1;
+  color: white;
+}
+
+.score-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.score-positive {
+  background: linear-gradient(135deg, var(--success-500, #10b981), var(--success-600, #059669));
+}
+
+.score-negative {
+  background: linear-gradient(135deg, var(--danger-500, #ef4444), var(--danger-600, #dc2626));
+}
+
+/* ========================================
+   Analysis Card - 分析結果カードの統一スタイル
+   ======================================== */
+.analysis-card.card {
+  border: 1px solid var(--gray-100, #f3f4f6);
+  border-radius: var(--radius-xl, 1rem);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.analysis-card .card-header {
+  background: var(--primary-50, #f0f5fa);
+  border-bottom: 1px solid var(--primary-100, #dce7f4);
+  border-left: 4px solid var(--primary-600, #4072B3);
+  padding: 1rem 1.25rem;
+}
+
+.analysis-card .card-header h5,
+.analysis-card .card-header h6 {
+  color: var(--primary-700, #2d5a8a);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* ========================================
+   Document Header - 書類詳細ヘッダー（ブランドカラー統一）
+   ======================================== */
+.document-header {
+  background: linear-gradient(135deg, var(--primary-700, #2d5a8a) 0%, var(--primary-600, #4072B3) 60%, var(--primary-500, #6088C6) 100%);
+  color: white;
+  padding: 2rem 1.5rem;
+  border-radius: var(--radius-2xl, 1.5rem);
+  margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+@media (min-width: 768px) {
+  .document-header {
+    padding: 2.5rem 2rem;
+  }
 }
 
 /* ========== Print Styles ========== */


### PR DESCRIPTION
各テンプレートがインライン:rootでCSS変数を上書きしてブランドカラー
(#4072B3)が崩れていた問題を修正。

- analysis-template.css: --at-primaryをブランドブルーに統一、
  .score-display/.analysis-card/.document-headerの共通スタイルを追加
- base.html: analysis-template.cssを全ページに一括読み込み
- simple_document_detail.html: :root上書きブロック削除、
  紫系グラデーション→ブランドブルーグラデーションに変更、
  重複Googleフォント読み込みを削除
- sentiment/result.html: :root上書きブロック削除、
  重複Googleフォント読み込みを削除
- financial/result.html: Bootstrap変数をブランドカラーに上書き

https://claude.ai/code/session_01WaaftuRNsbq6ysxSiKRzNf