### PR TITLE
モバイル日記一覧のスクロール体験とタップ性を改善

### DIFF
--- a/static/css/2-layouts/diary-card.css
+++ b/static/css/2-layouts/diary-card.css
@@ -325,13 +325,20 @@
   align-items: center;
   color: var(--accent-200);
   text-decoration: none;
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: gap 0.2s ease;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  transition: gap 0.2s ease, background 0.2s ease;
+  padding: 0.625rem 0.875rem;
+  min-height: 44px;
+  border-radius: var(--radius-md);
+  background: rgba(113, 196, 239, 0.08);
+  border: 1px solid rgba(113, 196, 239, 0.2);
+  margin-top: 0.5rem;
 }
 
 .read-more:hover {
-  gap: 0.25rem;
+  gap: 0.375rem;
+  background: rgba(113, 196, 239, 0.15);
 }
 
 .panel-loading {
@@ -496,10 +503,15 @@
 }
 
 .dark-mode .view-detail,
+[data-theme="dark"] .view-detail {
+  color: var(--accent-100);
+}
+
 .dark-mode .read-more,
-[data-theme="dark"] .view-detail,
 [data-theme="dark"] .read-more {
   color: var(--accent-100);
+  background: rgba(113, 196, 239, 0.1);
+  border-color: rgba(113, 196, 239, 0.25);
 }
 
 /* ========================================

--- a/stockdiary/templates/stockdiary/home.html
+++ b/stockdiary/templates/stockdiary/home.html
@@ -738,11 +738,13 @@
    ======================================== */
 @media (max-width: 991px) {
   html {
-    scroll-snap-type: y proximity;
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
   }
   .diary-article {
     scroll-snap-align: start;
-    scroll-margin-top: 0.5rem;
+    scroll-snap-stop: always;
+    scroll-margin-top: 1rem;
   }
 }
 </style>


### PR DESCRIPTION
- scroll-snap-type を proximity→mandatory に変更してカード単位のスナップを確実に
- scroll-snap-stop: always でスワイプ時のカードスキップを防止
- scroll-behavior: smooth でスナップアニメーションを滑らかに
- scroll-margin-top を 0.5rem→1rem に拡大してカードがナビバーに隠れないよう改善
- 「続きを読む」ボタンにパディング・ボーダー・背景を追加してタップ領域を 44px 以上に拡大
- 「続きを読む」のダークモード対応を強化

https://claude.ai/code/session_01Nwsp1KfxnF4etVkdfSUdT3