### PR TITLE
fix: ブラウザバック後にスピードダイヤルとメニューが操作不能になる問題を修正

### DIFF
--- a/static/js/speed-dial.js
+++ b/static/js/speed-dial.js
@@ -721,13 +721,13 @@ function createSpeedDial(options = {}) {
 function initializeSpeedDial() {
   const speedDial = new SpeedDial();
   window.speedDialInstance = speedDial;
-  
+
   // スピードダイヤルをDOM内で適切な位置に強制移動
   const speedDialContainer = document.querySelector('.speed-dial-container');
   if (speedDialContainer && speedDialContainer.parentElement !== document.body) {
     document.body.appendChild(speedDialContainer);
   }
-  
+
   // ページクリック時にポジションを確認・修正
   document.addEventListener('click', function() {
     const speedDial = document.querySelector('.speed-dial-container');
@@ -738,6 +738,13 @@ function initializeSpeedDial() {
 
   return speedDial;
 }
+
+// bfcache（ブラウザバック）からの復元時にスピードダイヤルをリセット
+window.addEventListener('pageshow', function(event) {
+  if (event.persisted && window.speedDialInstance) {
+    window.speedDialInstance.close();
+  }
+});
 
 // Intersection Observerによる遅延初期化
 let speedDialInitialized = false;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1348,6 +1348,14 @@
                   document.body.style.overflow = '';
               }
           });
+
+          // bfcache（ブラウザバック）からの復元時にメニュー状態をリセット
+          window.addEventListener('pageshow', function(event) {
+              if (event.persisted) {
+                  fullscreenMenu.classList.remove('active');
+                  document.body.style.overflow = '';
+              }
+          });
       });
   </script>
   <script src="{% static 'js/speed-dial.js' %}"></script>


### PR DESCRIPTION
bfcache（ブラウザ前後キャッシュ）からページが復元された際、
スピードダイヤルのオーバーレイやメニューが開いた状態のまま
復元されることで全画面がブロックされる問題を修正。

pageshow イベント（event.persisted === true）でスピードダイヤルと
フルスクリーンメニューの状態をリセットする。

https://claude.ai/code/session_019pbSmTba6YEGwWnwfRukuJ