### PR TITLE
feat: 日記一覧に開示書類インジケーターを追加

### DIFF
--- a/earnings_analysis/management/commands/daily_update.py
+++ b/earnings_analysis/management/commands/daily_update.py
@@ -174,7 +174,10 @@ class Command(BaseCommand):
                 self._update_company_master_optimized(target_date)
             else:
                 self.stdout.write('企業マスタ更新をスキップしました。')
-            
+
+            # 開示インジケーター更新
+            self._update_disclosure_indicators()
+
             # 成功処理
             self._record_batch_success(batch_execution, processed_count)
             success = True
@@ -1033,3 +1036,15 @@ class Command(BaseCommand):
             return datetime.strptime(datetime_str, '%Y-%m-%d %H:%M')
         except (ValueError, TypeError):
             return timezone.now()
+
+    def _update_disclosure_indicators(self):
+        """株式日記の開示インジケーターを更新"""
+        try:
+            from earnings_analysis.services.disclosure_sync import update_diary_disclosure_status
+            self.stdout.write('開示インジケーター更新中...')
+            updated = update_diary_disclosure_status()
+            self.stdout.write(self.style.SUCCESS(f'開示インジケーター更新完了: {updated}件'))
+        except Exception as e:
+            # インジケーター更新の失敗はバッチ全体を止めない
+            logger.warning(f'開示インジケーター更新エラー（スキップ）: {e}', exc_info=True)
+            self.stdout.write(self.style.WARNING(f'開示インジケーター更新スキップ: {e}'))

--- a/earnings_analysis/services/__init__.py
+++ b/earnings_analysis/services/__init__.py
@@ -17,11 +17,15 @@ from .xbrl_extractor import XBRLFinancialExtractor, EDINETXBRLService, CashFlowE
 # バッチサービス
 from .batch_service import BatchService
 
+# 開示インジケーター同期
+from .disclosure_sync import update_diary_disclosure_status
+
 __all__ = [
     'EdinetAPIClient',
-    'EdinetDocumentService', 
+    'EdinetDocumentService',
     'XBRLFinancialExtractor',
     'EDINETXBRLService',
     'CashFlowExtractor',
     'BatchService',
+    'update_diary_disclosure_status',
 ]

--- a/earnings_analysis/services/disclosure_sync.py
+++ b/earnings_analysis/services/disclosure_sync.py
@@ -1,0 +1,91 @@
+# earnings_analysis/services/disclosure_sync.py
+"""
+株式日記の開示書類インジケーター更新サービス
+
+EDINETの DocumentMetadata から各銘柄の最新開示日を取得し、
+StockDiary.latest_disclosure_date / latest_disclosure_doc_type_name を一括更新する。
+
+設計方針:
+- 日記一覧表示時の追加クエリは不要（事前計算フィールドに保存）
+- 日次バッチ（daily_update）完了後に呼び出される
+"""
+import logging
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+def update_diary_disclosure_status() -> int:
+    """
+    全ユーザーの StockDiary に最新開示日と書類種別を一括更新する。
+
+    Returns:
+        int: 更新した StockDiary レコード数
+    """
+    from stockdiary.models import StockDiary
+    from earnings_analysis.models import DocumentMetadata
+
+    # 4桁数字の銘柄コードを持つ日記を対象（日本株のみ）
+    diaries = list(
+        StockDiary.objects.filter(
+            stock_symbol__regex=r'^\d{4}$'
+        ).only('id', 'stock_symbol', 'latest_disclosure_date', 'latest_disclosure_doc_type_name')
+    )
+
+    if not diaries:
+        logger.info('開示インジケーター更新: 対象日記なし')
+        return 0
+
+    # 4桁コード → 5桁コード（末尾に '0' を付加）
+    symbol_to_securities = {d.stock_symbol: d.stock_symbol + '0' for d in diaries}
+    securities_codes = list(symbol_to_securities.values())
+
+    # EDINETの書類種別表示名マッピング
+    doc_type_names = DocumentMetadata.DOC_TYPE_DISPLAY_NAMES
+
+    # 銘柄ごとに最新の開示書類を取得
+    # DISTINCT ON を使い、securities_code ごとに最新の file_date のレコードを1件取得
+    latest_docs = (
+        DocumentMetadata.objects
+        .filter(
+            securities_code__in=securities_codes,
+            legal_status__in=['1', '2'],     # '1'=縦覧中, '2'=延長期間中
+            withdrawal_status='0',            # 取り下げられていない
+        )
+        .order_by('securities_code', '-file_date', '-submit_date_time')
+        .distinct('securities_code')
+        .values('securities_code', 'file_date', 'doc_type_code')
+    )
+
+    # securities_code（5桁）→ (file_date, doc_type_name) のマップを構築
+    disclosure_map: dict[str, tuple] = {
+        row['securities_code']: (
+            row['file_date'],
+            doc_type_names.get(row['doc_type_code'], f"書類種別{row['doc_type_code']}")
+        )
+        for row in latest_docs
+    }
+
+    # StockDiary を更新
+    to_update = []
+    for diary in diaries:
+        sec_code = symbol_to_securities[diary.stock_symbol]
+        info = disclosure_map.get(sec_code)
+        new_date = info[0] if info else None
+        new_name = info[1] if info else ''
+
+        if diary.latest_disclosure_date != new_date or diary.latest_disclosure_doc_type_name != new_name:
+            diary.latest_disclosure_date = new_date
+            diary.latest_disclosure_doc_type_name = new_name
+            to_update.append(diary)
+
+    if to_update:
+        StockDiary.objects.bulk_update(
+            to_update,
+            ['latest_disclosure_date', 'latest_disclosure_doc_type_name'],
+            batch_size=500,
+        )
+
+    updated_count = len(to_update)
+    logger.info(f'開示インジケーター更新完了: {updated_count}/{len(diaries)} 件更新')
+    return updated_count

--- a/static/css/3-components/badge.css
+++ b/static/css/3-components/badge.css
@@ -113,6 +113,61 @@
   color: var(--info-color);
 }
 
+/* ========== 開示書類インジケーター ========== */
+.disclosure-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.disclosure-indicator--recent {
+  background: rgba(59, 130, 246, 0.1);
+  color: #2563eb;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.disclosure-indicator--new {
+  background: rgba(16, 185, 129, 0.12);
+  color: #059669;
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  animation: disclosure-pulse 2.5s ease-in-out infinite;
+}
+
+.disclosure-indicator i {
+  font-size: 0.7rem;
+}
+
+.disclosure-date {
+  opacity: 0.85;
+}
+
+@keyframes disclosure-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.65; }
+}
+
+/* Dark mode */
+.dark-mode .disclosure-indicator--recent,
+[data-theme="dark"] .disclosure-indicator--recent {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.dark-mode .disclosure-indicator--new,
+[data-theme="dark"] .disclosure-indicator--new {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
 /* ========== アニメーション ========== */
 @keyframes fadeIn {
   from {

--- a/stockdiary/migrations/0002_add_disclosure_indicator.py
+++ b/stockdiary/migrations/0002_add_disclosure_indicator.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stockdiary', '0001_add_source_doc_id'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE stockdiary_stockdiary
+                    ADD COLUMN IF NOT EXISTS latest_disclosure_date DATE NULL DEFAULT NULL,
+                    ADD COLUMN IF NOT EXISTS latest_disclosure_doc_type_name VARCHAR(50) NOT NULL DEFAULT '';
+            """,
+            reverse_sql="""
+                ALTER TABLE stockdiary_stockdiary
+                    DROP COLUMN IF EXISTS latest_disclosure_date,
+                    DROP COLUMN IF EXISTS latest_disclosure_doc_type_name;
+            """,
+        ),
+    ]

--- a/stockdiary/models.py
+++ b/stockdiary/models.py
@@ -74,6 +74,14 @@ class StockDiary(models.Model):
     # 関連日記（非対称M2M：対称性はアプリ層で管理）
     linked_diaries = models.ManyToManyField('self', blank=True, symmetrical=False, related_name='linked_from', verbose_name='関連日記')
 
+    # 開示書類情報（EDINETから定期更新）
+    latest_disclosure_date = models.DateField(
+        null=True, blank=True, verbose_name='最新開示日'
+    )
+    latest_disclosure_doc_type_name = models.CharField(
+        max_length=50, blank=True, verbose_name='最新開示種別'
+    )
+
     # システム情報
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -111,6 +119,19 @@ class StockDiary(models.Model):
     def is_short(self):
         """信用売り（ショートポジション）かどうか"""
         return self.current_quantity < 0
+
+    @property
+    def recent_disclosure_status(self):
+        """開示書類の直近度: 'new'(7日以内), 'recent'(30日以内), None"""
+        if not self.latest_disclosure_date:
+            return None
+        from datetime import date
+        days = (date.today() - self.latest_disclosure_date).days
+        if days <= 7:
+            return 'new'
+        elif days <= 30:
+            return 'recent'
+        return None
 
     def update_aggregates(self):
         """集計フィールドを再計算"""

--- a/stockdiary/templates/stockdiary/partials/diary_card.html
+++ b/stockdiary/templates/stockdiary/partials/diary_card.html
@@ -34,6 +34,14 @@
       <div class="diary-meta-row">
         {% include "stockdiary/components/_date_display.html" with date=diary.created_at format="short" show_icon=True %}
         {% include "stockdiary/components/_status_badge.html" with diary=diary style="improved" size="sm" %}
+        {% if diary.recent_disclosure_status %}
+          <span class="disclosure-indicator disclosure-indicator--{{ diary.recent_disclosure_status }}"
+                title="{{ diary.latest_disclosure_date|date:'Y年m月d日' }}に開示：{{ diary.latest_disclosure_doc_type_name }}">
+            <i class="bi bi-file-earmark-text"></i>
+            <span class="disclosure-label">{% if diary.recent_disclosure_status == 'new' %}新着開示{% else %}開示{% endif %}</span>
+            <span class="disclosure-date">{{ diary.latest_disclosure_date|date:"m/d" }}</span>
+          </span>
+        {% endif %}
       </div>
 
       <!-- タグ行 - 独立 -->


### PR DESCRIPTION
- StockDiary に latest_disclosure_date / latest_disclosure_doc_type_name フィールドを追加
- recent_disclosure_status プロパティ ('new'=7日以内, 'recent'=30日以内) を追加
- earnings_analysis/services/disclosure_sync.py を新規作成
  - DISTINCT ON で銘柄ごとの最新開示書類を一括取得
  - bulk_update で StockDiary を効率的に更新
- daily_update バッチ完了後に開示インジケーターを自動更新
- 日記カードのメタ行に開示インジケーターバッジを表示
  - 7日以内: 緑「新着開示」（パルスアニメーション）
  - 30日以内: 青「開示」
- リスト表示時の追加クエリなし（事前計算フィールド方式）

https://claude.ai/code/session_01BnExm77NtF2afx54cvBvBQ