### PR TITLE
feat: 日記一覧に開示書類更新フィルターを追加

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -744,4 +744,4 @@ Q_CLUSTER = {
     'orm': 'default',
 }
 
-STATIC_VERSION = '1.1.5'
+STATIC_VERSION = '1.1.10'

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 // static/sw.js - シンプル版
-const VERSION = '1.1.5';  // ← CSS変更時はここだけ変更すればOK
+const VERSION = '1.1.10';  // ← CSS変更時はここだけ変更すればOK
 const CACHE_NAME = `kabulog-v${VERSION}`;
 const STATIC_CACHE_NAME = `kabulog-static-v${VERSION}`;
 

--- a/stockdiary/templates/stockdiary/home.html
+++ b/stockdiary/templates/stockdiary/home.html
@@ -1059,6 +1059,14 @@ button.read-more { font-family: inherit; cursor: pointer; }
         </select>
       </div>
       <div>
+        <label class="filter-group-label" for="disclosureFilter">開示書類の更新</label>
+        <select class="form-select" id="disclosureFilter" name="disclosure" form="optimizedSearchForm">
+          <option value="">指定なし</option>
+          <option value="new" {% if request.GET.disclosure == 'new' %}selected{% endif %}>直近1週間に更新あり</option>
+          <option value="recent" {% if request.GET.disclosure == 'recent' %}selected{% endif %}>直近1ヶ月に更新あり</option>
+        </select>
+      </div>
+      <div>
         <label class="filter-group-label" for="dateRangeFilter">購入時期</label>
         <select class="form-select" id="dateRangeFilter" name="date_range" form="optimizedSearchForm">
           <option value="">指定なし</option>
@@ -1202,7 +1210,7 @@ document.getElementById('filterApplyBtn').addEventListener('click', function() {
 });
 
 document.getElementById('filterResetBtn').addEventListener('click', function() {
-  ['tagFilter', 'sectorFilter', 'transactionDateRangeFilter', 'dateRangeFilter'].forEach(function(id) {
+  ['tagFilter', 'sectorFilter', 'transactionDateRangeFilter', 'dateRangeFilter', 'disclosureFilter'].forEach(function(id) {
     var el = document.getElementById(id);
     if (el) el.value = '';
   });
@@ -1252,6 +1260,7 @@ function removeFilter(filterName) {
     'sector': 'sectorFilter',
     'transaction_date_range': 'transactionDateRangeFilter',
     'date_range': 'dateRangeFilter',
+    'disclosure': 'disclosureFilter',
     'hashtag': 'hashtagFilter',
     'sort': 'sortFilter'
   };
@@ -1314,6 +1323,14 @@ function updateFilterBadges() {
     count++;
   }
 
+  var disclosureFilter = document.getElementById('disclosureFilter');
+  if (disclosureFilter && disclosureFilter.value) {
+    var disclosureText = { 'new': '1週間以内', 'recent': '1ヶ月以内' };
+    addFilterChip('disclosure', disclosureFilter.value,
+      '開示更新: ' + (disclosureText[disclosureFilter.value] || disclosureFilter.value));
+    count++;
+  }
+
   var hashtagFilter = document.getElementById('hashtagFilter');
   if (hashtagFilter && hashtagFilter.value) {
     addFilterChip('hashtag', hashtagFilter.value, '@' + hashtagFilter.value);
@@ -1366,7 +1383,7 @@ function resetSearch() {
   document.getElementById('mainSearchInput').value = '';
   document.getElementById('hashtagFilter').value = '';
   document.getElementById('sortFilter').value = '';
-  ['tagFilter', 'sectorFilter', 'transactionDateRangeFilter', 'dateRangeFilter'].forEach(function(id) {
+  ['tagFilter', 'sectorFilter', 'transactionDateRangeFilter', 'dateRangeFilter', 'disclosureFilter'].forEach(function(id) {
     var el = document.getElementById(id);
     if (el) el.value = '';
   });

--- a/stockdiary/views.py
+++ b/stockdiary/views.py
@@ -205,6 +205,17 @@ class StockDiaryListView(LoginRequiredMixin, ListView):
                 ).values_list('diary_id', flat=True).distinct()
                 queryset = queryset.filter(id__in=diary_ids)
         
+        # 開示書類更新フィルター
+        disclosure_filter = self.request.GET.get('disclosure', '')
+        if disclosure_filter == 'new':
+            from datetime import timedelta
+            cutoff = timezone.now().date() - timedelta(days=7)
+            queryset = queryset.filter(latest_disclosure_date__gte=cutoff)
+        elif disclosure_filter == 'recent':
+            from datetime import timedelta
+            cutoff = timezone.now().date() - timedelta(days=30)
+            queryset = queryset.filter(latest_disclosure_date__gte=cutoff)
+
         # 既存の日付範囲フィルター（first_purchase_date基準）
         date_range = self.request.GET.get('date_range', '')
         if date_range:
@@ -330,23 +341,34 @@ class StockDiaryListView(LoginRequiredMixin, ListView):
                     ).values_list('diary_id', flat=True).distinct()
                     queryset = queryset.filter(id__in=diary_ids)
             
+            # 開示書類更新フィルター
+            disclosure_filter = request.GET.get('disclosure', '')
+            if disclosure_filter == 'new':
+                from datetime import timedelta
+                cutoff = timezone.now().date() - timedelta(days=7)
+                queryset = queryset.filter(latest_disclosure_date__gte=cutoff)
+            elif disclosure_filter == 'recent':
+                from datetime import timedelta
+                cutoff = timezone.now().date() - timedelta(days=30)
+                queryset = queryset.filter(latest_disclosure_date__gte=cutoff)
+
             # 日付範囲フィルター
             date_range = request.GET.get('date_range', '')
             if date_range:
                 from datetime import timedelta
                 today = timezone.now().date()
-                
+
                 range_mapping = {
                     '1w': 7, '1m': 30, '3m': 90, '6m': 180, '1y': 365
                 }
-                
+
                 if date_range in range_mapping:
                     start_date = today - timedelta(days=range_mapping[date_range])
                     queryset = queryset.filter(
                         Q(first_purchase_date__gte=start_date) |
                         Q(first_purchase_date__isnull=True, created_at__gte=start_date)
                     )
-            
+
             # 🆕 ソート（取引回数・総取得原価を追加）
             sort = request.GET.get('sort', '')
             if sort == 'name':


### PR DESCRIPTION
フィルターパネルに「開示書類の更新」を追加し、直近1週間/1ヶ月に
EDINET開示書類の更新があった日記を抽出できるようにした。
- ListView.get_queryset()とdiary_list()の両方にdisclosure filterを追加
- フィルターパネルUI、フィルターチップ、リセット処理を対応

https://claude.ai/code/session_01UyMceobp2greAcJargJbaS