### PR TITLE
fix: プッシュ通知の403エラーとVAPID設定不足を修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,14 @@ EDINET_API_KEY=your_edinet_api_key_here
 # REDIS_HOST=localhost
 # REDIS_PORT=6379
 # REDIS_DB=0
+
+# Push Notifications (Web Push / VAPID)
+# ======================================
+# VAPIDキーペアの生成方法:
+#   pip install py-vapid
+#   vapid --gen
+# または:
+#   python -c "from py_vapid import Vapid; v = Vapid(); v.generate_keys(); print('Public:', v.public_key); print('Private:', v.private_key)"
+VAPID_PUBLIC_KEY=your-vapid-public-key-here
+VAPID_PRIVATE_KEY=your-vapid-private-key-here
+VAPID_ADMIN_EMAIL=your-admin-email@example.com

--- a/config/settings.py
+++ b/config/settings.py
@@ -63,8 +63,9 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = 'DENY'
 
-# CSRFトークンを常に検証
-CSRF_COOKIE_HTTPONLY = True
+# CSRF_COOKIE_HTTPONLY = True にするとJavaScriptがCSRFトークンを読めなくなり
+# fetchなどのAJAXリクエストでX-CSRFTokenヘッダーが送れず403エラーになるためFalseに設定
+CSRF_COOKIE_HTTPONLY = False
 
 # 2. セッション設定の強化
 SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
- CSRF_COOKIE_HTTPONLY を True→False に変更
  HTTPONLY=Trueだと JS から document.cookie でCSRFトークンが
  読めなくなり、fetchのX-CSRFTokenヘッダーがnullになって403エラーが発生
  （Djangoドキュメントでは AJAX利用時はFalseを推奨）

- .env.example にVAPIDキーの設定項目を追加
  VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_ADMIN_EMAIL が
  設定されていないとプッシュ通知の送信・受信ができないため明記

https://claude.ai/code/session_012hRaL3bJnajj44sUaByPBv