### PR TITLE
feat(stockdiary): 日記関連グラフに全画面モードを追加

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -741,4 +741,4 @@ Q_CLUSTER = {
     'orm': 'default',      # Redis不要: Django ORM (PostgreSQL) をブローカーとして使用
 }
 
-STATIC_VERSION = '1.2.19'
+STATIC_VERSION = '1.2.28'

--- a/static/css/graph-view.css
+++ b/static/css/graph-view.css
@@ -658,3 +658,115 @@ body.dark-mode .side-panel-footer,
 @media (max-width: 480px) {
   .graph-canvas { height: 360px; }
 }
+
+/* ================================================================
+   全画面モード（スマホで小さくて見えづらい問題への対策）
+   #graph-stage に .is-fullscreen が付与されたとき、
+   フィルターバー + グラフ本体を画面全体に拡大表示する。
+   ================================================================ */
+
+/* 通常時のステージは普通のブロックレイアウト（スタイル無効化） */
+.graph-stage { /* no-op */ }
+
+/* 全画面ステージ: 画面全体を覆う */
+.graph-stage.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 1080;
+  background: var(--bg-100, #fffefb);
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+  gap: 8px;
+  /* iOS Safari のアドレスバー伸縮対策 */
+  height: 100vh;
+  height: 100dvh;
+}
+
+/* 全画面時: フィルターバーは余白を詰める */
+.graph-stage.is-fullscreen .graph-filter-bar {
+  margin-bottom: 0 !important;
+  flex-shrink: 0;
+}
+
+/* 全画面時: グラフ本体は残りの全領域を占有 */
+.graph-stage.is-fullscreen .graph-outer-wrapper {
+  flex: 1;
+  min-height: 0;
+}
+
+/* 全画面時: グラフコンテナを最大化、角丸・枠を消してフラットに */
+.graph-stage.is-fullscreen .graph-container {
+  height: 100%;
+  border-radius: 0;
+}
+
+/* 全画面時: キャンバスと SVG を 100% に */
+.graph-stage.is-fullscreen .graph-canvas {
+  height: 100%;
+}
+
+.graph-stage.is-fullscreen #diary-graph-svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* 全画面時のサイドパネル（モバイル: 下からドロワー、PC: 右からドロワー） */
+@media (min-width: 769px) {
+  .graph-stage.is-fullscreen .graph-side-panel.open {
+    width: 320px;
+  }
+}
+
+@media (max-width: 768px) {
+  .graph-stage.is-fullscreen .graph-side-panel.open {
+    max-height: 45%;
+  }
+}
+
+/* 全画面終了ボタン（フローティング・通常時は非表示） */
+.graph-fullscreen-exit-btn {
+  display: none;
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 6;
+  width: 38px;
+  height: 38px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bg-100, #fffefb);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  color: var(--text-100, #1d1c1c);
+  font-size: 1rem;
+  padding: 0;
+  cursor: pointer;
+}
+
+.graph-stage.is-fullscreen .graph-fullscreen-exit-btn {
+  display: flex;
+}
+
+.graph-fullscreen-exit-btn:hover {
+  background: var(--bg-200, #f5f4f1);
+}
+
+body.dark-mode .graph-fullscreen-exit-btn,
+[data-theme="dark"] .graph-fullscreen-exit-btn {
+  background: var(--dm-card, #1e1e2e);
+  border-color: var(--dm-border, rgba(255, 255, 255, 0.15));
+  color: var(--dm-foreground, #e0e0e0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode .graph-fullscreen-exit-btn:hover,
+[data-theme="dark"] .graph-fullscreen-exit-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* 全画面モード中はページのスクロールを抑制 */
+body.graph-fullscreen-active {
+  overflow: hidden;
+}

--- a/static/js/diary-graph.js
+++ b/static/js/diary-graph.js
@@ -177,6 +177,25 @@
       if (closeBtn) {
         closeBtn.addEventListener('click', () => this._closeSidePanel());
       }
+
+      const fsBtn = document.getElementById('toggleFullscreen');
+      if (fsBtn) {
+        fsBtn.addEventListener('click', () => this._toggleFullscreen());
+      }
+      const exitFsBtn = document.getElementById('exitFullscreen');
+      if (exitFsBtn) {
+        exitFsBtn.addEventListener('click', () => this._toggleFullscreen(false));
+      }
+      document.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && this._isFullscreen) {
+          this._toggleFullscreen(false);
+        }
+      });
+      // ウィンドウリサイズ時（端末回転など）はセンター追従のみ。手動 zoom/pan は維持
+      window.addEventListener('resize', () => {
+        if (this._resizeTimer) clearTimeout(this._resizeTimer);
+        this._resizeTimer = setTimeout(() => this._handleResize(false), 150);
+      });
     }
 
     // ==============================
@@ -595,6 +614,57 @@
         const sel = animate ? this.svg.transition().duration(500) : this.svg;
         sel.call(this.zoomBehavior.transform, t);
       } catch (_) { /* getBBox が利用できない環境では無視 */ }
+    }
+
+    // ==============================
+    // 全画面モード切替（スマホでノードが見えづらい問題対応）
+    // ==============================
+    _toggleFullscreen(force) {
+      const stage = document.getElementById('graph-stage');
+      if (!stage) return;
+      const next = (typeof force === 'boolean')
+        ? force
+        : !stage.classList.contains('is-fullscreen');
+
+      stage.classList.toggle('is-fullscreen', next);
+      document.body.classList.toggle('graph-fullscreen-active', next);
+      this._isFullscreen = next;
+
+      const btn = document.getElementById('toggleFullscreen');
+      if (btn) {
+        const icon = btn.querySelector('i');
+        if (icon) {
+          icon.className = next ? 'bi bi-fullscreen-exit' : 'bi bi-arrows-fullscreen';
+        }
+        btn.setAttribute('title', next ? '全画面を終了' : '全画面表示');
+        btn.setAttribute('aria-pressed', next ? 'true' : 'false');
+      }
+
+      // CSS のレイアウト変更が反映されてから再センター + フィット（明示操作なので強制フィット）
+      this._handleResize(true);
+    }
+
+    // ==============================
+    // 描画領域サイズ変更時の再センター/フィット
+    //   forceFit=true: 全体が見える位置に強制リフィット（全画面トグル時）
+    //   forceFit=false: シミュレーション中心のみ更新、ユーザーの zoom/pan は維持
+    // ==============================
+    _handleResize(forceFit) {
+      if (!this.svg || !this.simulation) return;
+      requestAnimationFrame(() => {
+        const svgEl = this.svgEl;
+        const w = svgEl.clientWidth  || svgEl.parentElement.clientWidth  || 800;
+        const h = svgEl.clientHeight || svgEl.parentElement.clientHeight || 600;
+        const centerForce = this.simulation.force('center');
+        if (centerForce) {
+          centerForce.x(w / 2).y(h / 2);
+        }
+        this.simulation.alpha(0.2).restart();
+        if (forceFit) {
+          this._userHasInteracted = false;
+          this._fitToView(true);
+        }
+      });
     }
 
     // ==============================

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 // static/sw.js - シンプル版
-const VERSION = '1.2.19';  // ← CSS変更時はここだけ変更すればOK
+const VERSION = '1.2.28';  // ← CSS変更時はここだけ変更すればOK
 const CACHE_NAME = `kabulog-v${VERSION}`;
 const STATIC_CACHE_NAME = `kabulog-static-v${VERSION}`;
 

--- a/stockdiary/templates/stockdiary/diary_graph.html
+++ b/stockdiary/templates/stockdiary/diary_graph.html
@@ -27,6 +27,9 @@
     </div>
   </div>
 
+  <!-- グラフステージ（フィルターバー + グラフ本体。全画面トグルの対象） -->
+  <div id="graph-stage" class="graph-stage">
+
   <!-- フィルターバー -->
   <div class="graph-filter-bar mb-3" id="graph-controls">
     <div id="ctrl-panel">
@@ -111,7 +114,10 @@
             <label class="form-check-label small" for="showLabels">ラベル</label>
           </div>
           <button class="btn btn-outline-secondary btn-sm" id="resetZoom" title="ズームリセット">
-            <i class="bi bi-fullscreen-exit"></i>
+            <i class="bi bi-aspect-ratio"></i>
+          </button>
+          <button class="btn btn-outline-secondary btn-sm" id="toggleFullscreen" title="全画面表示" aria-pressed="false">
+            <i class="bi bi-arrows-fullscreen"></i>
           </button>
         </div>
       </div>
@@ -156,6 +162,11 @@
         <span id="stats-edges" class="badge bg-secondary"></span>
       </div>
 
+      <!-- 全画面終了ボタン（全画面モード時のみ表示） -->
+      <button id="exitFullscreen" class="graph-fullscreen-exit-btn" type="button" title="全画面を終了" aria-label="全画面を終了">
+        <i class="bi bi-x-lg"></i>
+      </button>
+
     </div><!-- /.graph-container -->
 
     <!-- サイドパネル（ノードクリックで展開） -->
@@ -172,6 +183,8 @@
     </div>
 
   </div><!-- /.graph-outer-wrapper -->
+
+  </div><!-- /#graph-stage -->
 
   <!-- 凡例 -->
   <div class="d-flex gap-3 mt-2 flex-wrap align-items-center" id="graph-legend">


### PR DESCRIPTION
スマホ画面でノードが小さく見えづらいため、グラフを画面全体に拡大表示する
全画面モードを実装。フィルターバー＋グラフ本体を `#graph-stage` ラッパーで
括り、`.is-fullscreen` 切替で `position: fixed; inset: 0` 化する。

- ツールバーに `bi-arrows-fullscreen` トグルボタン、グラフ右上に
  フローティング終了ボタン、Escape キーでも終了可能
- 全画面切替時はフォースシミュレーションのセンターを更新し
  `_fitToView` で全ノードを再フィット
- iOS Safari 対応に `100dvh` を併用、ダークモードのスタイルも追加
- ズームリセットボタンのアイコンを `bi-fullscreen-exit`（紛らわしい）から
  `bi-aspect-ratio` に変更